### PR TITLE
Feat: 템플릿 등록 및 관리 기능 추가

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,7 +33,12 @@ export default function Navbar({ currentCategory, onCategoryChange }: NavbarProp
     <nav className="bg-surface border-b border-border sticky top-0 z-[1000]">
       <div className="max-w-[1400px] mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
         <div className="flex items-center">
-          <span className="text-base sm:text-lg md:text-xl lg:text-2xl font-bold text-primary whitespace-nowrap">템플릿 테스터</span>
+          <span
+            onClick={() => navigate("/")}
+            className="text-base sm:text-lg md:text-xl lg:text-2xl font-bold text-primary whitespace-nowrap cursor-pointer"
+          >
+            템플릿 테스터
+          </span>
         </div>
         <div className="flex items-center gap-3 sm:gap-4">
           <div className="flex gap-1 sm:gap-2">
@@ -53,11 +58,7 @@ export default function Navbar({ currentCategory, onCategoryChange }: NavbarProp
             <div className="flex items-center gap-2 sm:gap-3 ml-2 sm:ml-4 pl-2 sm:pl-4 border-l border-border">
               <div className="hidden sm:flex items-center gap-2">
                 {user.photoURL && (
-                  <img
-                    src={user.photoURL}
-                    alt={user.displayName || "User"}
-                    className="w-7 h-7 rounded-full"
-                  />
+                  <img src={user.photoURL} alt={user.displayName || "User"} className="w-7 h-7 rounded-full" />
                 )}
                 <span className="text-xs sm:text-sm text-textSecondary max-w-[100px] truncate">
                   {user.displayName || user.email}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+}
+
+export default function PageHeader({ title, description, actions }: PageHeaderProps) {
+  return (
+    <div className="mb-6">
+      <div className="flex items-center gap-4 mb-4 min-h-[40px] sm:min-h-[48px]">
+        <h2 className="hidden sm:block text-lg sm:text-xl md:text-2xl font-bold text-text m-0">{title}</h2>
+        {actions}
+      </div>
+      {description && <p className="text-sm text-textSecondary m-0">{description}</p>}
+    </div>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-export type ButtonVariant = "primary" | "secondary" | "success" | "error";
+export type ButtonVariant = "primary" | "secondary" | "success" | "error" | "ghost";
 export type ButtonSize = "sm" | "md" | "lg";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -13,6 +13,7 @@ const variantClasses: Record<ButtonVariant, string> = {
   secondary: "bg-transparent text-primary border border-primary hover:bg-blue-100 hover:text-blue-700 hover:border-blue-600",
   success: "bg-success text-surface hover:bg-green-600 hover:-translate-y-px hover:shadow-[0_2px_8px_rgba(187,247,208,1)]",
   error: "bg-error text-surface hover:bg-red-600 hover:-translate-y-px hover:shadow-[0_2px_8px_rgba(254,202,202,1)]",
+  ghost: "bg-transparent text-textSecondary hover:bg-blue-50 hover:text-primary",
 };
 
 const sizeClasses: Record<ButtonSize, string> = {

--- a/src/components/ui/SelectBox.tsx
+++ b/src/components/ui/SelectBox.tsx
@@ -66,12 +66,12 @@ export default function SelectBox({
   };
 
   const buttonClasses = [
-    "appearance-none select-custom-arrow",
-    "border border-border rounded-md bg-surface text-text cursor-pointer transition-all duration-200 ease-in-out outline-none",
-    "hover:border-primary focus:border-primary focus:ring-2 focus:ring-blue-200",
+    "box-border appearance-none select-custom-arrow",
+    "outline outline-1 outline-border rounded-md bg-surface text-text cursor-pointer transition-all duration-200 ease-in-out",
+    "hover:outline-primary focus:outline-primary focus:ring-2 focus:ring-blue-200",
     "flex items-center justify-between",
+    "w-full",
     sizeClasses[selectSize],
-    fullWidth && "w-full",
     disabled && "opacity-50 cursor-not-allowed",
     !currentValue && "text-textSecondary",
     className,
@@ -80,7 +80,7 @@ export default function SelectBox({
     .join(" ");
 
   return (
-    <div ref={dropdownRef} className="relative inline-block">
+    <div ref={dropdownRef} className={`relative ${fullWidth ? 'w-full' : 'w-64'}`}>
       <button
         type="button"
         className={buttonClasses}
@@ -101,7 +101,7 @@ export default function SelectBox({
       </button>
 
       {isOpen && (
-        <div className="absolute z-50 w-full mt-1 bg-surface border border-border rounded-lg shadow-lg max-h-60 overflow-auto scrollbar-hide">
+        <div className="box-border absolute z-50 w-full mt-1 bg-surface outline outline-1 outline-border rounded-lg shadow-lg max-h-60 overflow-auto scrollbar-hide">
           {placeholder && (
             <div
               className="px-4 py-2 text-sm text-textSecondary hover:bg-blue-50 cursor-pointer transition-colors"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,8 @@ import './index.css'
 import App from './App.tsx'
 import Login from './pages/Login.tsx'
 import Signup from './pages/Signup.tsx'
+import TemplateRegistration from './pages/TemplateRegistration.tsx'
+import MyTemplates from './pages/MyTemplates.tsx'
 import ProtectedRoute from './components/ProtectedRoute.tsx'
 import { AuthProvider } from './contexts/AuthContext.tsx'
 
@@ -20,6 +22,22 @@ createRoot(document.getElementById('root')!).render(
             element={
               <ProtectedRoute>
                 <App />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/template-registration"
+            element={
+              <ProtectedRoute>
+                <TemplateRegistration />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/my-templates"
+            element={
+              <ProtectedRoute>
+                <MyTemplates />
               </ProtectedRoute>
             }
           />

--- a/src/pages/MyTemplates.tsx
+++ b/src/pages/MyTemplates.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import Navbar from "../components/Navbar";
+import PageHeader from "../components/PageHeader";
+import Button from "../components/ui/Button";
+import { getUserTemplatesByCategory, deleteUserTemplate } from "../firebase/services";
+import type { Category, Template } from "../types";
+
+function MyTemplates() {
+  const navigate = useNavigate();
+  const [currentCategory, setCurrentCategory] = useState<Category>("algorithm");
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    loadTemplates();
+  }, [currentCategory]);
+
+  const loadTemplates = async () => {
+    try {
+      setIsLoading(true);
+      const data = await getUserTemplatesByCategory(currentCategory);
+      setTemplates(data);
+    } catch (error) {
+      console.error("템플릿 로드 실패:", error);
+      alert("템플릿을 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCategoryChange = (category: Category) => {
+    setCurrentCategory(category);
+  };
+
+  const handleEdit = (templateId: string) => {
+    navigate(`/template-registration?id=${templateId}`);
+  };
+
+  const handleDelete = async (templateId: string, title: string) => {
+    if (!confirm(`"${title}" 템플릿을 삭제하시겠습니까?`)) {
+      return;
+    }
+
+    try {
+      await deleteUserTemplate(templateId);
+      alert("템플릿이 삭제되었습니다.");
+      loadTemplates();
+    } catch (error) {
+      console.error("템플릿 삭제 실패:", error);
+      alert("템플릿 삭제에 실패했습니다.");
+    }
+  };
+
+  const handleCreateNew = () => {
+    navigate("/template-registration");
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar currentCategory={currentCategory} onCategoryChange={handleCategoryChange} />
+
+      <div className="max-w-[1400px] mx-auto px-6 py-6">
+        <PageHeader title="내 템플릿 관리" description="등록한 템플릿을 확인하고 수정/삭제할 수 있습니다." />
+
+        <div className="mb-6 flex justify-end">
+          <Button onClick={handleCreateNew} variant="primary">
+            새 템플릿 등록
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <div className="text-center py-12 text-textSecondary">템플릿을 불러오는 중...</div>
+        ) : templates.length === 0 ? (
+          <div className="bg-surface p-12 rounded-lg border border-border text-center">
+            <p className="text-textSecondary mb-4">등록된 템플릿이 없습니다.</p>
+            <Button onClick={handleCreateNew} variant="primary">
+              템플릿 등록하기
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {templates.map((template) => (
+              <div
+                key={template.id}
+                className="bg-surface p-6 rounded-lg border border-border hover:border-primary transition-colors"
+              >
+                <div className="flex justify-between items-start">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-3 mb-2">
+                      <h3 className="text-lg font-semibold text-text m-0">{template.title}</h3>
+                      <span className="px-2 py-1 bg-primary/10 text-primary text-xs rounded">
+                        {template.type === "paragraph" ? "줄글형" : "문제형"}
+                      </span>
+                    </div>
+                    {template.description && <p className="text-sm text-textSecondary mb-3">{template.description}</p>}
+                    <div className="text-xs text-textSecondary">
+                      등록일: {template.createdAt?.toLocaleDateString("ko-KR")}
+                    </div>
+                  </div>
+
+                  <div className="flex">
+                    <Button onClick={() => handleEdit(template.id)} variant="ghost" size="sm">
+                      수정
+                    </Button>
+                    <Button onClick={() => handleDelete(template.id, template.title)} variant="ghost" size="sm">
+                      삭제
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MyTemplates;

--- a/src/pages/TemplateRegistration.tsx
+++ b/src/pages/TemplateRegistration.tsx
@@ -1,0 +1,247 @@
+import { useState, useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import Navbar from "../components/Navbar";
+import PageHeader from "../components/PageHeader";
+import Button from "../components/ui/Button";
+import SelectBox from "../components/ui/SelectBox";
+import CodeEditor from "../components/CodeEditor";
+import { saveUserTemplate, updateUserTemplate, getUserTemplates } from "../firebase/services";
+import type { Category, TemplateType } from "../types";
+
+function TemplateRegistration() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const templateId = searchParams.get("id");
+  const isEditMode = !!templateId;
+
+  const [currentCategory, setCurrentCategory] = useState<Category>("algorithm");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [templateType, setTemplateType] = useState<TemplateType>("paragraph");
+  const [answer, setAnswer] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (isEditMode && templateId) {
+      loadTemplateData(templateId);
+    }
+  }, [isEditMode, templateId]);
+
+  const loadTemplateData = async (id: string) => {
+    try {
+      setIsLoading(true);
+      const templates = await getUserTemplates();
+      const template = templates.find((t) => t.id === id);
+
+      if (!template) {
+        alert("템플릿을 찾을 수 없습니다.");
+        navigate("/");
+        return;
+      }
+
+      setCurrentCategory(template.category);
+      setTitle(template.title);
+      setDescription(template.description || "");
+      setAnswer(template.answer);
+      setTemplateType(template.type || "paragraph");
+    } catch (error) {
+      console.error("템플릿 로드 실패:", error);
+      alert("템플릿을 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCategoryChange = (category: Category) => {
+    setCurrentCategory(category);
+  };
+
+  const handleSubmit = async () => {
+    if (!title.trim()) {
+      alert("템플릿 제목을 입력해주세요.");
+      return;
+    }
+
+    if (!answer.trim()) {
+      alert("정답 내용을 입력해주세요.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+
+      if (isEditMode && templateId) {
+        await updateUserTemplate(
+          templateId,
+          currentCategory,
+          title,
+          description,
+          answer,
+          templateType
+        );
+        alert("템플릿이 성공적으로 수정되었습니다!");
+      } else {
+        await saveUserTemplate(
+          currentCategory,
+          title,
+          description,
+          answer,
+          templateType
+        );
+        alert("템플릿이 성공적으로 등록되었습니다!");
+      }
+
+      navigate("/my-templates");
+    } catch (error: any) {
+      console.error("템플릿 저장 실패:", error);
+      alert(error.message || "템플릿 저장에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleReset = () => {
+    setTitle("");
+    setDescription("");
+    setAnswer("");
+    setTemplateType("paragraph");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-text">템플릿 로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar currentCategory={currentCategory} onCategoryChange={handleCategoryChange} />
+
+      <div className="max-w-[1400px] mx-auto px-6 py-6">
+        <PageHeader
+          title={isEditMode ? "템플릿 수정" : "템플릿 등록"}
+          description={isEditMode ? "등록한 템플릿을 수정합니다." : "나만의 템플릿을 등록하고 연습해보세요."}
+        />
+
+        {/* 템플릿 정보 입력 */}
+        <div className="bg-surface p-6 rounded-lg border border-border mb-6">
+          {/* 카테고리 선택 */}
+          <div className="mb-6">
+            <label className="block text-sm font-semibold text-text mb-2">
+              카테고리
+            </label>
+            <SelectBox
+              value={currentCategory}
+              onChange={(e) => setCurrentCategory(e.target.value as Category)}
+              options={[
+                { value: "algorithm", label: "알고리즘" },
+                { value: "cs", label: "CS" },
+                { value: "english", label: "영어" },
+                { value: "interview", label: "면접" },
+              ]}
+              fullWidth
+            />
+          </div>
+
+          {/* 템플릿 제목 */}
+          <div className="mb-6">
+            <label className="block text-sm font-semibold text-text mb-2">
+              템플릿 제목
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="예: 이분 탐색 알고리즘"
+              className="w-full px-4 py-2 bg-background border border-border rounded-lg text-text placeholder-textSecondary focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+
+          {/* 템플릿 설명 */}
+          <div className="mb-6">
+            <label className="block text-sm font-semibold text-text mb-2">
+              템플릿 설명
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="예: 정렬되어 있는 리스트에서 탐색 범위를 절반씩 좁혀가며 데이터를 탐색하는 알고리즘"
+              rows={3}
+              className="w-full px-4 py-2 bg-background border border-border rounded-lg text-text placeholder-textSecondary focus:outline-none focus:ring-2 focus:ring-primary resize-none"
+            />
+          </div>
+
+          {/* 템플릿 형태 선택 */}
+          <div className="mb-6">
+            <label className="block text-sm font-semibold text-text mb-3">
+              템플릿 형태
+            </label>
+            <div className="flex gap-6">
+              <label className="flex items-center cursor-pointer">
+                <input
+                  type="radio"
+                  name="templateType"
+                  value="paragraph"
+                  checked={templateType === "paragraph"}
+                  onChange={(e) => setTemplateType(e.target.value as TemplateType)}
+                  className="w-4 h-4 text-primary bg-background border-border focus:ring-primary focus:ring-2"
+                />
+                <span className="ml-2 text-text">줄글형</span>
+              </label>
+              <label className="flex items-center cursor-pointer">
+                <input
+                  type="radio"
+                  name="templateType"
+                  value="problem"
+                  checked={templateType === "problem"}
+                  onChange={(e) => setTemplateType(e.target.value as TemplateType)}
+                  className="w-4 h-4 text-primary bg-background border-border focus:ring-primary focus:ring-2"
+                />
+                <span className="ml-2 text-text">문제형</span>
+              </label>
+            </div>
+            {templateType === "problem" && (
+              <p className="mt-2 text-xs text-textSecondary">
+                문제형은 서술형으로 입력하되, "1. ~~~" / "2. ~~~" 형식으로 입력해주세요.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* 정답 입력 영역 */}
+        <div className="mb-6">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-semibold text-text m-0">정답 입력</h3>
+            <div className="flex gap-2">
+              <Button onClick={handleReset} variant="secondary">
+                초기화
+              </Button>
+              <Button onClick={handleSubmit} variant="primary" disabled={isSubmitting}>
+                {isSubmitting
+                  ? (isEditMode ? "수정 중..." : "등록 중...")
+                  : (isEditMode ? "템플릿 수정" : "템플릿 등록")}
+              </Button>
+            </div>
+          </div>
+          <CodeEditor value={answer} onChange={setAnswer} language="python" />
+        </div>
+
+        {/* 안내 메시지 */}
+        <div className="bg-surface p-4 rounded-lg border border-border">
+          <h4 className="text-sm font-semibold text-text mb-2">입력 가이드</h4>
+          <ul className="text-xs text-textSecondary space-y-1 list-disc list-inside">
+            <li>템플릿 제목은 간결하고 명확하게 작성해주세요.</li>
+            <li>정답 내용은 나중에 테스트할 때 기준이 되는 정답입니다.</li>
+            <li>채점 시 주석, 띄어쓰기, 줄 바꿈은 무시됩니다.</li>
+            <li>문제형은 "1. 첫 번째 답", "2. 두 번째 답" 형식으로 입력하면 좋습니다.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TemplateRegistration;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export type Category = 'algorithm' | 'english' | 'cs' | 'interview';
+export type TemplateType = 'paragraph' | 'problem'; // 줄글형 | 문제형
 
 export interface Template {
   id: string;
@@ -6,6 +7,9 @@ export interface Template {
   title: string;
   description: string;
   answer: string; // 정답 코드
+  type?: TemplateType; // 템플릿 형태 (기존 템플릿은 optional)
+  userId?: string; // 유저가 등록한 템플릿인 경우
+  createdAt?: Date; // 생성 시간
 }
 
 export interface GradingResult {


### PR DESCRIPTION
- 템플릿 등록 페이지(TemplateRegistration) 구현
  - 사용자 정의 템플릿 등록 기능
  - 카테고리, 제목, 설명, 정답 코드 입력
  - Firebase Firestore에 템플릿 저장
- 내 템플릿 페이지(MyTemplates) 구현
  - 사용자가 등록한 템플릿 목록 조회
  - 템플릿 삭제 기능
  - 템플릿 상세 정보 표시
- PageHeader 컴포넌트 추가
  - 페이지 제목 및 설명 표시용 재사용 컴포넌트
- Navbar에 페이지 네비게이션 추가
  - 템플릿 테스터, 템플릿 등록, 내 템플릿 메뉴
- Firebase 서비스 확장
  - 템플릿 CRUD 함수 추가
  - getUserTemplates, saveTemplate, deleteTemplate 구현
- UI 컴포넌트 개선
  - Button에 loading 상태 추가
  - SelectBox 스타일 개선