### PR TITLE
Feat: 오답노트 언어 선택 필드 추가 및 CodeEditor 접기/펼치기 기능 구현

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Editor from "@monaco-editor/react";
 
 interface CodeEditorProps {
@@ -6,6 +7,9 @@ interface CodeEditorProps {
   language?: string;
   readOnly?: boolean;
   height?: string;
+  collapsible?: boolean;
+  defaultCollapsed?: boolean;
+  title?: string;
 }
 
 export default function CodeEditor({
@@ -14,7 +18,55 @@ export default function CodeEditor({
   language = "javascript",
   readOnly = false,
   height = "600px",
+  collapsible = false,
+  defaultCollapsed = false,
+  title,
 }: CodeEditorProps) {
+  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+
+  if (collapsible) {
+    return (
+      <div className="border border-border rounded-md overflow-hidden bg-[#1e1e1e]">
+        <button
+          type="button"
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          className="w-full flex items-center justify-between px-4 py-3 text-left text-gray-300 hover:bg-[#2d2d2d] transition-colors"
+        >
+          <span className="text-sm font-medium">{title || "코드"}</span>
+          <svg
+            className={`w-4 h-4 transition-transform ${isCollapsed ? "" : "rotate-180"}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+        {!isCollapsed && (
+          <div className="py-3">
+            <Editor
+              height={height}
+              language={language}
+              value={value}
+              onChange={(newValue) => onChange(newValue || "")}
+              theme="vs-dark"
+              options={{
+                minimap: { enabled: false },
+                fontSize: 14,
+                lineNumbers: "on",
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+                tabSize: 2,
+                wordWrap: "on",
+                readOnly,
+              }}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="border border-border rounded-md overflow-hidden bg-[#1e1e1e] py-3">
       <Editor

--- a/src/firebase/services.ts
+++ b/src/firebase/services.ts
@@ -499,6 +499,7 @@ export interface WrongNote {
   userId: string;
   userEmail: string | null;
   link: string;
+  language: string;
   date: string;
   platform: string;
   grade: string;
@@ -564,6 +565,7 @@ export async function getWrongNotes(): Promise<WrongNote[]> {
         userId: data.userId,
         userEmail: data.userEmail,
         link: data.link,
+        language: data.language || "",
         date: data.date,
         platform: data.platform,
         grade: data.grade,

--- a/src/pages/WrongNoteDetail.tsx
+++ b/src/pages/WrongNoteDetail.tsx
@@ -45,6 +45,19 @@ const resultOptions = [
   { value: "wrong", label: "틀림" },
 ];
 
+// 언어 옵션
+const languageOptions = [
+  { value: "python", label: "Python" },
+  { value: "javascript", label: "JavaScript" },
+  { value: "java", label: "Java" },
+  { value: "cpp", label: "C++" },
+  { value: "c", label: "C" },
+  { value: "kotlin", label: "Kotlin" },
+  { value: "swift", label: "Swift" },
+  { value: "go", label: "Go" },
+  { value: "rust", label: "Rust" },
+];
+
 // 플랫폼 라벨 변환
 const getPlatformLabel = (value: string) => {
   return platformOptions.find((p) => p.value === value)?.label || value;
@@ -71,8 +84,14 @@ const getTagLabels = (tags: string[]) => {
   return tags.map((t) => tagOptions.find((opt) => opt.value === t)?.label || t);
 };
 
+// 언어 라벨 변환
+const getLanguageLabel = (value: string) => {
+  return languageOptions.find((l) => l.value === value)?.label || value;
+};
+
 interface FormData {
   link: string;
+  language: string;
   date: string;
   platform: string;
   grade: string;
@@ -93,6 +112,7 @@ export default function WrongNoteDetail() {
   const [isSaving, setIsSaving] = useState(false);
   const [formData, setFormData] = useState<FormData>({
     link: "",
+    language: "",
     date: "",
     platform: "",
     grade: "",
@@ -113,6 +133,7 @@ export default function WrongNoteDetail() {
         if (found) {
           setFormData({
             link: found.link,
+            language: found.language || "",
             date: found.date,
             platform: found.platform,
             grade: found.grade,
@@ -181,6 +202,7 @@ export default function WrongNoteDetail() {
     if (note) {
       setFormData({
         link: note.link,
+        language: note.language || "",
         date: note.date,
         platform: note.platform,
         grade: note.grade,
@@ -232,17 +254,29 @@ export default function WrongNoteDetail() {
           <PageHeader title="오답노트 수정" />
 
           <div className="mt-6 space-y-6">
-            {/* 문제 링크 */}
-            <div>
-              <label className="block text-sm font-medium text-text mb-2">문제 링크</label>
-              <input
-                type="url"
-                value={formData.link}
-                onChange={(e) => handleInputChange("link", e.target.value)}
-                placeholder="https://programmers.co.kr/..."
-                className="w-full px-4 py-2 text-sm outline outline-1 outline-border rounded-md bg-surface text-text
-                  hover:outline-primary focus:outline-primary focus:ring-2 focus:ring-blue-200 transition-all"
-              />
+            {/* 문제 링크 & 언어 */}
+            <div className="grid grid-cols-1 md:grid-cols-[1fr_200px] gap-4">
+              <div>
+                <label className="block text-sm font-medium text-text mb-2">문제 링크</label>
+                <input
+                  type="url"
+                  value={formData.link}
+                  onChange={(e) => handleInputChange("link", e.target.value)}
+                  placeholder="https://programmers.co.kr/..."
+                  className="w-full px-4 py-2 text-sm outline outline-1 outline-border rounded-md bg-surface text-text
+                    hover:outline-primary focus:outline-primary focus:ring-2 focus:ring-blue-200 transition-all"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-text mb-2">언어</label>
+                <SelectBox
+                  options={languageOptions}
+                  value={formData.language}
+                  onChange={(e) => handleInputChange("language", e.target.value)}
+                  placeholder="언어 선택"
+                  fullWidth
+                />
+              </div>
             </div>
 
             {/* 날짜 & 플랫폼 & 등급 */}
@@ -422,16 +456,26 @@ export default function WrongNoteDetail() {
           </div>
 
           {/* 문제 링크 */}
-          <div>
-            <h3 className="text-sm font-medium text-textSecondary mb-1">문제 링크</h3>
-            <a
-              href={note.link}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary hover:underline break-all"
-            >
-              {note.link}
-            </a>
+          <div className="flex items-start gap-4">
+            <div className="flex-1">
+              <h3 className="text-sm font-medium text-textSecondary mb-1">문제 링크</h3>
+              <a
+                href={note.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline break-all"
+              >
+                {note.link}
+              </a>
+            </div>
+            {note.language && (
+              <div>
+                <h3 className="text-sm font-medium text-textSecondary mb-1">언어</h3>
+                <span className="px-2 py-0.5 text-xs rounded bg-purple-100 text-purple-700">
+                  {getLanguageLabel(note.language)}
+                </span>
+              </div>
+            )}
           </div>
 
           {/* 작성 이유 */}
@@ -458,18 +502,26 @@ export default function WrongNoteDetail() {
 
           {/* 내 풀이 */}
           {note.myCode && (
-            <div>
-              <h3 className="text-sm font-medium text-textSecondary mb-2">내 풀이</h3>
-              <CodeEditor value={note.myCode} onChange={() => {}} readOnly height="400px" />
-            </div>
+            <CodeEditor
+              value={note.myCode}
+              onChange={() => {}}
+              readOnly
+              height="400px"
+              collapsible
+              title="내 풀이"
+            />
           )}
 
           {/* 참조한 풀이 */}
           {note.solution && (
-            <div>
-              <h3 className="text-sm font-medium text-textSecondary mb-2">참조한 풀이</h3>
-              <CodeEditor value={note.solution} onChange={() => {}} readOnly height="400px" />
-            </div>
+            <CodeEditor
+              value={note.solution}
+              onChange={() => {}}
+              readOnly
+              height="400px"
+              collapsible
+              title="참조한 풀이"
+            />
           )}
         </div>
       </div>

--- a/src/pages/WrongNotes.tsx
+++ b/src/pages/WrongNotes.tsx
@@ -45,8 +45,22 @@ const resultOptions = [
   { value: "wrong", label: "틀림" },
 ];
 
+// 언어 옵션
+const languageOptions = [
+  { value: "python", label: "Python" },
+  { value: "javascript", label: "JavaScript" },
+  { value: "java", label: "Java" },
+  { value: "cpp", label: "C++" },
+  { value: "c", label: "C" },
+  { value: "kotlin", label: "Kotlin" },
+  { value: "swift", label: "Swift" },
+  { value: "go", label: "Go" },
+  { value: "rust", label: "Rust" },
+];
+
 interface FormData {
   link: string;
+  language: string;
   date: string;
   platform: string;
   grade: string;
@@ -95,6 +109,7 @@ export default function WrongNotes() {
   const [activeTab, setActiveTab] = useState<"write" | "list">("list");
   const [formData, setFormData] = useState<FormData>({
     link: "",
+    language: "",
     date: new Date().toISOString().split("T")[0],
     platform: "",
     grade: "",
@@ -169,6 +184,7 @@ export default function WrongNotes() {
   const resetForm = () => {
     setFormData({
       link: "",
+      language: "",
       date: new Date().toISOString().split("T")[0],
       platform: "",
       grade: "",
@@ -349,14 +365,12 @@ export default function WrongNotes() {
                             </>
                           )}
                         </div>
-                        {note.comment && (
-                          <p className="mt-2 text-sm text-textSecondary line-clamp-2">{note.comment}</p>
-                        )}
+                        {note.comment ? <p className="mt-2 text-sm text-textSecondary line-clamp-2">{note.comment}</p> : null}
                       </div>
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
-                          note.id && handleDelete(note.id);
+                          if (note.id) handleDelete(note.id);
                         }}
                         className="p-2 text-textSecondary hover:text-error transition-colors"
                       >
@@ -380,17 +394,29 @@ export default function WrongNotes() {
         {/* 작성 탭 */}
         {activeTab === "write" && (
           <div className="mt-6 space-y-6">
-            {/* 문제 사이트 링크 */}
-            <div>
-              <label className="block text-sm font-medium text-text mb-2">문제 링크</label>
-              <input
-                type="url"
-                value={formData.link}
-                onChange={(e) => handleInputChange("link", e.target.value)}
-                placeholder="https://programmers.co.kr/..."
-                className="w-full px-4 py-2 text-sm outline outline-1 outline-border rounded-md bg-surface text-text
-                  hover:outline-primary focus:outline-primary focus:ring-2 focus:ring-blue-200 transition-all"
-              />
+            {/* 문제 링크 & 언어 */}
+            <div className="grid grid-cols-1 md:grid-cols-[1fr_200px] gap-4">
+              <div>
+                <label className="block text-sm font-medium text-text mb-2">문제 링크</label>
+                <input
+                  type="url"
+                  value={formData.link}
+                  onChange={(e) => handleInputChange("link", e.target.value)}
+                  placeholder="https://programmers.co.kr/..."
+                  className="w-full px-4 py-2 text-sm outline outline-1 outline-border rounded-md bg-surface text-text
+                    hover:outline-primary focus:outline-primary focus:ring-2 focus:ring-blue-200 transition-all"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-text mb-2">언어</label>
+                <SelectBox
+                  options={languageOptions}
+                  value={formData.language}
+                  onChange={(e) => handleInputChange("language", e.target.value)}
+                  placeholder="언어 선택"
+                  fullWidth
+                />
+              </div>
             </div>
 
             {/* 날짜 & 플랫폼 & 등급 */}
@@ -497,7 +523,6 @@ export default function WrongNotes() {
           </div>
         )}
       </div>
-
     </div>
   );
 }


### PR DESCRIPTION
- WrongNote 타입에 language 필드 추가
- 오답노트 작성/수정 폼에 언어 선택 SelectBox 추가
- 오답노트 상세 페이지에 언어 표시
- CodeEditor 컴포넌트에 collapsible, defaultCollapsed, title props 추가
- 오답노트 상세 페이지의 코드 에디터에 접기/펼치기 기능 적용