### PR TITLE
Refactor: Chip UI 컴포넌트 분리 및 오답노트 페이지에 적용

### DIFF
--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,0 +1,22 @@
+export type ChipVariant = "primary" | "secondary" | "success" | "warning" | "error" | "purple";
+
+interface ChipProps {
+  variant?: ChipVariant;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const variantClasses: Record<ChipVariant, string> = {
+  primary: "bg-blue-100 text-primary",
+  secondary: "bg-gray-100 text-textSecondary",
+  success: "bg-green-100 text-green-700",
+  warning: "bg-yellow-100 text-yellow-700",
+  error: "bg-red-100 text-red-700",
+  purple: "bg-purple-100 text-purple-700",
+};
+
+export default function Chip({ variant = "primary", children, className = "" }: ChipProps) {
+  const classes = ["px-2 py-0.5 text-xs rounded", variantClasses[variant], className].filter(Boolean).join(" ");
+
+  return <span className={classes}>{children}</span>;
+}

--- a/src/pages/WrongNoteDetail.tsx
+++ b/src/pages/WrongNoteDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import PageHeader from "../components/PageHeader";
 import Button from "../components/ui/Button";
+import Chip from "../components/ui/Chip";
 import SelectBox from "../components/ui/SelectBox";
 import ToggleButtonGroup from "../components/ui/ToggleButtonGroup";
 import CodeEditor from "../components/CodeEditor";
@@ -402,25 +403,17 @@ export default function WrongNoteDetail() {
           {/* 헤더 */}
           <div className="flex justify-between items-start">
             <div className="flex flex-wrap items-center gap-2">
-              <span className="px-2 py-0.5 text-xs rounded bg-blue-100 text-primary">
-                {getPlatformLabel(note.platform)}
-              </span>
+              <Chip variant="primary">{getPlatformLabel(note.platform)}</Chip>
               {note.grade && (
-                <span className="px-2 py-0.5 text-xs rounded bg-gray-100 text-textSecondary">
-                  {getGradeLabel(note.platform, note.grade)}
-                </span>
+                <Chip variant="secondary">{getGradeLabel(note.platform, note.grade)}</Chip>
               )}
-              <span
-                className={`px-2 py-0.5 text-xs rounded ${
-                  note.result === "correct"
-                    ? "bg-green-100 text-green-700"
-                    : note.result === "timeout"
-                      ? "bg-yellow-100 text-yellow-700"
-                      : "bg-red-100 text-red-700"
-                }`}
+              <Chip
+                variant={
+                  note.result === "correct" ? "success" : note.result === "timeout" ? "warning" : "error"
+                }
               >
                 {getResultLabel(note.result)}
-              </span>
+              </Chip>
               <span className="text-xs text-textSecondary ml-2">{note.date}</span>
             </div>
             <div className="flex items-center gap-1">
@@ -471,9 +464,7 @@ export default function WrongNoteDetail() {
             {note.language && (
               <div>
                 <h3 className="text-sm font-medium text-textSecondary mb-1">언어</h3>
-                <span className="px-2 py-0.5 text-xs rounded bg-purple-100 text-purple-700">
-                  {getLanguageLabel(note.language)}
-                </span>
+                <Chip variant="purple">{getLanguageLabel(note.language)}</Chip>
               </div>
             )}
           </div>

--- a/src/pages/WrongNotes.tsx
+++ b/src/pages/WrongNotes.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import PageHeader from "../components/PageHeader";
 import Button from "../components/ui/Button";
+import Chip from "../components/ui/Chip";
 import SelectBox from "../components/ui/SelectBox";
 import ToggleButtonGroup from "../components/ui/ToggleButtonGroup";
 import CodeEditor from "../components/CodeEditor";
@@ -327,25 +328,21 @@ export default function WrongNotes() {
                     <div className="flex justify-between items-start">
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-2">
-                          <span className="px-2 py-0.5 text-xs rounded bg-blue-100 text-primary">
-                            {getPlatformLabel(note.platform)}
-                          </span>
+                          <Chip variant="primary">{getPlatformLabel(note.platform)}</Chip>
                           {note.grade && (
-                            <span className="px-2 py-0.5 text-xs rounded bg-gray-100 text-textSecondary">
-                              {getGradeLabel(note.platform, note.grade)}
-                            </span>
+                            <Chip variant="secondary">{getGradeLabel(note.platform, note.grade)}</Chip>
                           )}
-                          <span
-                            className={`px-2 py-0.5 text-xs rounded ${
+                          <Chip
+                            variant={
                               note.result === "correct"
-                                ? "bg-green-100 text-green-700"
+                                ? "success"
                                 : note.result === "timeout"
-                                  ? "bg-yellow-100 text-yellow-700"
-                                  : "bg-red-100 text-red-700"
-                            }`}
+                                  ? "warning"
+                                  : "error"
+                            }
                           >
                             {getResultLabel(note.result)}
-                          </span>
+                          </Chip>
                         </div>
                         <a
                           href={note.link}


### PR DESCRIPTION
- 재사용 가능한 Chip 컴포넌트 생성 (primary, secondary, success, warning, error, purple 변형 지원)
- WrongNotes, WrongNoteDetail 페이지의 인라인 태그 스타일을 Chip 컴포넌트로 교체