### PR TITLE
Test: #51 커스텀 Hook 단위 테스트 추가

### DIFF
--- a/Template-Tester_FE/.claude/rules/fe-convention.md
+++ b/Template-Tester_FE/.claude/rules/fe-convention.md
@@ -15,17 +15,17 @@
 ```
 src/
 ├── app/                    # 앱 초기화 (진입점)
-│   ├── plugins/            # 플러그인 (pinia, vue-query 등)
+│   ├── providers/          # Provider 래퍼 (QueryClient, Router 등)
 │   ├── router/             # 라우터 설정
 │   ├── layouts/            # 레이아웃 컴포넌트
-│   └── styles/             # 전역 스타일
-├── pages/                  # 페이지 (file-based routing)
+│   └── styles/             # 전역 스타일 (Tailwind base)
+├── pages/                  # 페이지 컴포넌트
 ├── widgets/                # 복합 UI 블록 (여러 features 조합)
 ├── features/               # 기능 단위 (사용자 행동)
 ├── entities/               # 비즈니스 엔티티
 │   └── {entity}/
 │       ├── api/            # API 함수
-│       ├── model/          # composables, types, store
+│       ├── model/          # hooks, types, store
 │       └── ui/             # 엔티티 관련 UI
 └── shared/                 # 공유 자원
     ├── api/                # API 클라이언트, 공통 타입
@@ -56,28 +56,61 @@ src/
 
 ## 상태 관리
 
-### Pinia (클라이언트 상태)
+### Zustand (클라이언트 상태)
 
 - UI 상태, 사용자 설정, 앱 전역 상태에 사용
-- Composition API stores 사용
 - 파일 위치: `entities/{entity}/model/*.store.ts` 또는 `shared/model/*.store.ts`
 
 ```typescript
 // entities/user/model/user.store.ts
-import { defineStore } from 'pinia'
+import { create } from 'zustand'
+import type { User } from './user.type'
 
-export const useUserStore = defineStore('user', () => {
-  const currentUser = ref<User | null>(null)
+interface UserState {
+  currentUser: User | null
+  setUser: (user: User) => void
+  clearUser: () => void
+}
 
-  function setUser(user: User) {
-    currentUser.value = user
-  }
-
-  return { currentUser, setUser }
-})
+export const useUserStore = create<UserState>((set) => ({
+  currentUser: null,
+  setUser: (user) => set({ currentUser: user }),
+  clearUser: () => set({ currentUser: null }),
+}))
 ```
 
-### Vue Query (서버 상태)
+#### Zustand 미들웨어 활용 (권장)
+
+```typescript
+// persist 미들웨어로 localStorage 자동 동기화
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      theme: 'light',
+      setTheme: (theme) => set({ theme }),
+    }),
+    { name: 'settings-storage' }
+  )
+)
+```
+
+#### Selector 패턴 (강제)
+
+불필요한 리렌더링을 방지하기 위해 반드시 selector를 사용합니다.
+
+```typescript
+// ✅ 필요한 상태만 구독
+const currentUser = useUserStore((state) => state.currentUser)
+const setUser = useUserStore((state) => state.setUser)
+
+// ❌ 전체 store 구독 금지
+const store = useUserStore()
+```
+
+### TanStack Query (서버 상태)
 
 - API 데이터 캐싱, 자동 리페치, 낙관적 업데이트에 사용
 - 파일 위치: `entities/{entity}/model/use{Entity}Query.ts`
@@ -99,19 +132,19 @@ export const reportKeys = {
 }
 ```
 
-#### 반응형 Query 파라미터 (권장)
+#### Query Hook 패턴 (권장)
 
-필터 조건이 변경되면 자동으로 재조회되도록 `computed`로 파라미터를 전달합니다.
+파라미터가 변경되면 자동으로 재조회됩니다.
 
 ```typescript
 // entities/report/model/useReportQuery.ts
-import { useQuery } from '@tanstack/vue-query'
-import { computed, type Ref, type ComputedRef } from 'vue'
+import { useQuery } from '@tanstack/react-query'
+import { reportApi } from '../api/report.api'
 
-export function useReportListQuery(params: Ref<GetReportsParams> | ComputedRef<GetReportsParams>) {
+export function useReportListQuery(params: GetReportsParams) {
   return useQuery({
-    queryKey: computed(() => reportKeys.list(params.value)),
-    queryFn: () => reportApi.getReportList(params.value),
+    queryKey: reportKeys.list(params),
+    queryFn: () => reportApi.getReportList(params),
     select: (response) => ({
       data: response.data as ReportListItem[],
       total: response.pageInfo?.total ?? 0,
@@ -120,53 +153,52 @@ export function useReportListQuery(params: Ref<GetReportsParams> | ComputedRef<G
 }
 ```
 
-#### Query와 필터 Composable 조합 패턴 (권장)
+#### Query와 필터 Hook 조합 패턴 (권장)
 
-페이지 로직은 필터 상태 관리와 Query를 조합한 Composable로 분리합니다.
+페이지 로직은 필터 상태 관리와 Query를 조합한 커스텀 Hook으로 분리합니다.
 
 ```typescript
 // entities/report/model/useReportList.ts
-import { computed, ref, watch } from 'vue'
-import { watchDebounced } from '@vueuse/core'
+import { useState, useMemo, useEffect } from 'react'
+import { useDebounce } from '@/shared/lib/useDebounce'
 import { useReportListQuery, useReportSummaryQuery, useTeamsQuery } from './useReportQuery'
 
 export function useReportList() {
   // ===== 필터 상태 =====
-  const dateRange = ref<DateRange>({ start: defaultStart, end: defaultEnd })
-  const selectedTeams = ref<string[]>([])
-  const searchKeyword = ref('')
-  const debouncedSearchKeyword = ref('')
-  const currentPage = ref(1)
-  const pageSize = ref(DEFAULT_PAGE_SIZE)
+  const [dateRange, setDateRange] = useState<DateRange>({ start: defaultStart, end: defaultEnd })
+  const [selectedTeams, setSelectedTeams] = useState<string[]>([])
+  const [searchKeyword, setSearchKeyword] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
 
   // 디바운스 처리
-  watchDebounced(searchKeyword, (v) => { debouncedSearchKeyword.value = v }, { debounce: 300 })
+  const debouncedSearchKeyword = useDebounce(searchKeyword, 300)
 
-  // ===== Query 파라미터 (computed) =====
-  const listParams = computed<GetReportsParams>(() => ({
-    startDate: formatDateParam(dateRange.value.start),
-    endDate: formatDateParam(dateRange.value.end),
-    teamIds: selectedTeams.value.length > 0 ? selectedTeams.value : undefined,
-    q: debouncedSearchKeyword.value || undefined,
-    page: currentPage.value,
-    pageSize: pageSize.value,
-  }))
+  // ===== Query 파라미터 (memo) =====
+  const listParams = useMemo<GetReportsParams>(() => ({
+    startDate: formatDateParam(dateRange.start),
+    endDate: formatDateParam(dateRange.end),
+    teamIds: selectedTeams.length > 0 ? selectedTeams : undefined,
+    q: debouncedSearchKeyword || undefined,
+    page: currentPage,
+    pageSize,
+  }), [dateRange, selectedTeams, debouncedSearchKeyword, currentPage, pageSize])
 
-  // ===== Vue Query Hooks =====
+  // ===== TanStack Query Hooks =====
   const { data: listData, isLoading, isFetching } = useReportListQuery(listParams)
   const { data: summaryData } = useReportSummaryQuery(summaryParams)
   const { data: teamsData } = useTeamsQuery()
 
-  // ===== Computed 데이터 =====
-  const reportData = computed(() => listData.value?.data ?? [])
-  const totalCount = computed(() => listData.value?.total ?? 0)
+  // ===== 파생 데이터 =====
+  const reportData = listData?.data ?? []
+  const totalCount = listData?.total ?? 0
 
   // 필터 변경 시 페이지 리셋
-  watch([dateRange, selectedTeams, debouncedSearchKeyword], () => {
-    currentPage.value = 1
-  }, { deep: true })
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [dateRange, selectedTeams, debouncedSearchKeyword])
 
-  return { dateRange, selectedTeams, searchKeyword, reportData, totalCount, isLoading, ... }
+  return { dateRange, setDateRange, selectedTeams, setSelectedTeams, searchKeyword, setSearchKeyword, reportData, totalCount, isLoading, ... }
 }
 ```
 
@@ -189,6 +221,8 @@ export function useTeamsQuery() {
 
 ```typescript
 // 생성 mutation
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
 export function useCreateUserMutation() {
   const queryClient = useQueryClient()
 
@@ -201,17 +235,17 @@ export function useCreateUserMutation() {
 }
 ```
 
-### Pinia vs Vue Query 사용 기준
+### Zustand vs TanStack Query 사용 기준
 
-| 상황                      | 사용 라이브러리     |
-| ------------------------- | ------------------- |
-| API 응답 데이터 캐싱      | Vue Query           |
-| 서버 데이터 실시간 동기화 | Vue Query           |
-| 낙관적 업데이트           | Vue Query           |
-| 폼 상태 관리              | Pinia 또는 로컬 ref |
-| 모달/사이드바 열림 상태   | Pinia 또는 로컬 ref |
-| 사용자 인증 정보          | Pinia               |
-| 테마/언어 설정            | Pinia               |
+| 상황                      | 사용 라이브러리           |
+| ------------------------- | ------------------------- |
+| API 응답 데이터 캐싱      | TanStack Query            |
+| 서버 데이터 실시간 동기화 | TanStack Query            |
+| 낙관적 업데이트           | TanStack Query            |
+| 폼 상태 관리              | Zustand 또는 로컬 useState |
+| 모달/사이드바 열림 상태   | Zustand 또는 로컬 useState |
+| 사용자 인증 정보          | Zustand                   |
+| 테마/언어 설정            | Zustand                   |
 
 ---
 
@@ -226,10 +260,10 @@ export function useCreateUserMutation() {
 
 `shared/ui/` 컴포넌트 수정 시 반드시 함께 수정:
 
-1. **Storybook 스토리 파일** (`*.stories.ts`)
+1. **Storybook 스토리 파일** (`*.stories.tsx`)
    - 새로운 prop 추가 시 → argTypes에 추가, 해당 prop 사용하는 스토리 추가
    - prop 삭제/변경 시 → 기존 스토리 업데이트
-2. **테스트 파일** (`*.spec.ts`, `*.test.ts`)
+2. **테스트 파일** (`*.spec.ts`, `*.test.tsx`)
    - 테스트가 존재하는 경우 → 영향받는 테스트 케이스 수정
    - 새로운 기능 추가 시 → 테스트 케이스 추가 권장
 
@@ -253,139 +287,258 @@ export function useCreateUserMutation() {
 
 ## 스타일링
 
-- design token 변수와 함께 SCSS 사용
-- 적용 가능한 곳에 BEM 네이밍 컨벤션 준수
-- 자동 주입되는 token 변수 활용
-- **중요**: `src/shared/ui/theme/tokens/build/scss/variables.scss`에 존재하는 SCSS 변수만 사용
+- Tailwind CSS를 사용한 유틸리티 퍼스트 스타일링
+- 디자인 토큰은 `tailwind.config.ts`에서 theme으로 관리
+- **중요**: `tailwind.config.ts`에 정의된 커스텀 토큰만 사용
 
-### 사용 가능한 SCSS 변수
+### Tailwind 설정 (Design Tokens)
 
-> **참고**: 실제 변수는 `src/shared/ui/theme/tokens/build/scss/_variables.scss` 파일 참조
+디자인 토큰은 `tailwind.config.ts`의 `theme.extend`에서 관리합니다.
 
-**Colors:**
+```typescript
+// tailwind.config.ts
+import type { Config } from 'tailwindcss'
 
-- Base: `$color-white`, `$color-black`
-- Primary Blue: `$color-primary-blue-100` ~ `$color-primary-blue-900`
-- Primary Purple: `$color-primary-purple-100` ~ `$color-primary-purple-900`
-- Secondary GrayBlue: `$color-secondary-grayblue-100` ~ `$color-secondary-grayblue-900`
-- Gray: `$color-gray-100` ~ `$color-gray-900`
-- Neutral: `$color-neutral-100` ~ `$color-neutral-900`
-- Green: `$color-green-100` ~ `$color-green-900`
-- Yellow: `$color-yellow-100` ~ `$color-yellow-900`
-- Error: `$color-sub-error-100` ~ `$color-sub-error-900`
-- Info: `$color-sub-info-100` ~ `$color-sub-info-900`
+export default {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        'primary-blue': {
+          100: '#E8F0FE', /* ... */ 900: '#0D2B6B',
+        },
+        'primary-purple': {
+          100: '#F3E8FF', /* ... */ 900: '#3B0764',
+        },
+        // secondary, gray, neutral, green, yellow, error, info ...
+      },
+      fontFamily: {
+        pretendard: ['Pretendard', 'sans-serif'],
+      },
+      fontSize: {
+        12: ['12px', { lineHeight: '140%' }],
+        14: ['14px', { lineHeight: '140%' }],
+        16: ['16px', { lineHeight: '140%' }],
+        18: ['18px', { lineHeight: '140%' }],
+        20: ['20px', { lineHeight: '140%' }],
+        24: ['24px', { lineHeight: '140%' }],
+        28: ['28px', { lineHeight: '140%' }],
+        32: ['32px', { lineHeight: '140%' }],
+      },
+      fontWeight: {
+        regular: '400',
+        semibold: '600',
+        bold: '700',
+      },
+    },
+  },
+} satisfies Config
+```
 
-**Typography (복합 font shorthand):**
+### Tailwind 사용 규칙 (강제)
 
-- Headline: `$headline-h1` (700 32px), `$headline-h2` (600 28px), `$headline-h3` (600 20px), `$headline-h4` (600 18px), `$headline-h5` (600 16px), `$headline-h6` (600 14px/140%)
-- Body: `$body-b24`, `$body-b20`, `$body-b18`, `$body-b16`, `$body-b14`, `$body-b12` (모두 400 weight, 140% line-height)
+```tsx
+// ✅ 디자인 토큰 기반 클래스 사용
+<button className="bg-primary-blue-500 text-white font-semibold text-14 px-4 py-2 rounded">
+  확인
+</button>
 
-**Typography (개별 속성):**
+// ✅ 조건부 스타일링은 clsx/cn 유틸리티 사용
+import { cn } from '@/shared/lib/cn'
 
-- Font family: `$font-family-pretendard`
-- Font weights: `$font-weight-bold` (700), `$font-weight-semibold` (600), `$font-weight-regular` (400)
-- Font sizes: `$font-size-12`, `$font-size-14`, `$font-size-16`, `$font-size-18`, `$font-size-20`, `$font-size-24`, `$font-size-28`, `$font-size-32`
-- Line heights: `$font-line-height-140` (140%), `$font-line-height-auto` (normal)
+<button className={cn(
+  'px-4 py-2 rounded font-semibold text-14',
+  variant === 'primary' && 'bg-primary-blue-500 text-white',
+  variant === 'secondary' && 'bg-gray-100 text-gray-900',
+  disabled && 'opacity-50 cursor-not-allowed'
+)}>
+  {children}
+</button>
+
+// ❌ 인라인 스타일 사용 금지 (예외: 동적 값만 허용)
+<div style={{ color: 'red' }}>금지</div>
+
+// ❌ 임의 값(arbitrary values) 남용 금지
+<div className="w-[137px]">최소화</div>
+```
+
+### cn 유틸리티 (강제)
+
+조건부 클래스 조합을 위해 `clsx` + `tailwind-merge` 기반 `cn` 유틸리티를 사용합니다.
+
+```typescript
+// shared/lib/cn.ts
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+```
 
 ---
 
 ## Design Token 빌드 프로세스
 
-- `src/shared/ui/theme/tokens/` 하위에 JSON 형식으로 tokens 정의
-- Style Dictionary와 커스텀 transforms로 빌드
-- 모든 stylesheets에 자동 주입되는 SCSS 변수 생성
+- `tailwind.config.ts`의 `theme.extend`에서 디자인 토큰 정의
+- 필요 시 `src/shared/ui/theme/tokens/` 하위에 JSON 형식으로 원본 토큰 관리
+- Style Dictionary로 빌드 후 Tailwind config에 반영
 
 ---
 
 ## 파일 네이밍 컨벤션
 
-- **Components**: PascalCase 디렉토리와 PascalCase.vue 파일
-- **Atoms**: `shared/ui/atoms/{ComponentName}/{ComponentName}.vue`
-- **Molecules**: `shared/ui/molecules/{ComponentName}/{ComponentName}.vue`
+- **Components**: PascalCase 디렉토리와 PascalCase.tsx 파일
+- **Atoms**: `shared/ui/atoms/{ComponentName}/{ComponentName}.tsx`
+- **Molecules**: `shared/ui/molecules/{ComponentName}/{ComponentName}.tsx`
+- **Hooks**: `use*.ts` (커스텀 Hook)
 - **Stores**: `*.store.ts`
 - **Types**: TypeScript 정의용 `*.type.ts`
 - **APIs**: API 레이어 정의용 `*.api.ts`
-- **Queries**: Vue Query hooks용 `use*Query.ts`
+- **Queries**: TanStack Query hooks용 `use*Query.ts`
 
 ---
 
 ## Import 전략
 
 - src root에서 absolute imports를 위해 `@/` alias 사용
-- 페이지 컴포넌트는 file-based routing 활용
 - barrel export (`index.ts`)를 통한 public API 노출
 - 프로젝트 코드는 명시적 import 사용 (FSD 레이어 경계 명확화)
 
-### Auto-import 범위
+### Import 규칙 (강제)
 
-다음은 import 문 없이 사용 가능합니다:
+React에서는 auto-import를 사용하지 않습니다. 모든 의존성을 명시적으로 import합니다.
 
-| 종류 | 대상 | 예시 |
-|------|------|------|
-| Vue API | `vue` 전체 | `ref`, `computed`, `watch`, `onMounted` |
-| Vue Router API | `vue-router` 전체 | `useRouter`, `useRoute` |
-| 컴포넌트 | `shared/ui`, `widgets/**/ui`, `features/**/ui`, `entities/**/ui` | `AppButton`, `AppDialog` |
-| Composables | `src/composables/` | |
-| Utils | `src/utils/` | |
+```typescript
+// ✅ React hooks
+import { useState, useMemo, useEffect, useCallback } from 'react'
 
-**명시적 import 필요**:
-- 타입 (`import type { ... }`)
-- API 함수 (`entities/**/api`, `shared/api`)
-- Model (`entities/**/model`, `features/**/model`)
-- 외부 라이브러리
+// ✅ React Router
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
 
-**Claude 코드 작성 규칙 (강제)**:
-- 위 auto-import 대상은 import 문 생략
-- 그 외는 반드시 명시적 import 작성
+// ✅ 외부 라이브러리
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { create } from 'zustand'
+
+// ✅ 프로젝트 내부 (절대 경로)
+import { AppButton } from '@/shared/ui/atoms/AppButton'
+import { cn } from '@/shared/lib/cn'
+import type { User } from '@/entities/user/model/user.type'
+import { useUserStore } from '@/entities/user/model/user.store'
+```
+
+### Import 정렬 순서 (권장)
+
+```typescript
+// 1. React
+import { useState, useEffect } from 'react'
+
+// 2. 외부 라이브러리
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+
+// 3. 프로젝트 내부 (shared → entities → features → widgets)
+import { cn } from '@/shared/lib/cn'
+import { AppButton } from '@/shared/ui/atoms/AppButton'
+import type { User } from '@/entities/user/model/user.type'
+
+// 4. 상대 경로 (같은 슬라이스 내부)
+import { useUserForm } from '../model/useUserForm'
+```
 
 ---
 
-## Vue 컨벤션
+## React 컨벤션
 
-### SFC 블록 순서 (강제)
+### 컴포넌트 작성 패턴 (강제)
 
-1. `<script setup lang="ts">`
-2. `<template>`
-3. `<style scoped>`
+```tsx
+// entities/user/ui/UserCard/UserCard.tsx
+
+// 1. Props 인터페이스 정의
+interface UserCardProps {
+  user: User
+  onSelect?: (userId: number) => void
+}
+
+// 2. 함수 선언식 컴포넌트 (export는 named export)
+export function UserCard({ user, onSelect }: UserCardProps) {
+  // 3. 이벤트 핸들러
+  const handleClick = () => {
+    onSelect?.(user.id)
+  }
+
+  // 4. JSX 반환
+  return (
+    <div className="p-4 border rounded-lg" onClick={handleClick}>
+      <h3 className="font-semibold text-16">{user.name}</h3>
+      <p className="text-gray-500 text-14">{user.email}</p>
+    </div>
+  )
+}
+```
 
 ### 비즈니스 로직 분리 (강제)
 
-- `pages/*` 또는 단일 `.vue` 파일에 로직 집중 금지
-- 컴포넌트에는 UI 이벤트 처리만
+- `pages/*` 또는 단일 컴포넌트 파일에 로직 집중 금지
+- 컴포넌트에는 UI 렌더링과 이벤트 핸들러 연결만
 
-| 유형                         | 위치                                                        |
-| ---------------------------- | ----------------------------------------------------------- |
-| Vue 반응성/라이프사이클 결합 | `entities/{entity}/model/` 또는 `features/{feature}/model/` |
-| 순수 로직 (계산, 포맷, 매핑) | `shared/lib/`                                               |
-| 전역 상태                    | `*.store.ts`                                                |
-| 서버 상태                    | `use*Query.ts` (Vue Query)                                  |
+| 유형                                | 위치                                                        |
+| ----------------------------------- | ----------------------------------------------------------- |
+| React hooks (상태/사이드이펙트 결합) | `entities/{entity}/model/` 또는 `features/{feature}/model/` |
+| 순수 로직 (계산, 포맷, 매핑)        | `shared/lib/`                                               |
+| 전역 상태                           | `*.store.ts` (Zustand)                                      |
+| 서버 상태                           | `use*Query.ts` (TanStack Query)                             |
 
 ### 컴포넌트 책임 제한 (강제)
 
-Vue 파일은 다음 역할만 담당:
+컴포넌트 파일은 다음 역할만 담당:
 
-- props/emits 정의
-- UI 렌더링
+- Props 인터페이스 정의
+- UI 렌더링 (JSX)
 - 이벤트 핸들러 연결
 
 **금지 사항:**
 
-- 50줄 이상의 `<script setup>` 로직
+- 50줄 이상의 컴포넌트 로직
 - API 호출 직접 작성
 - 복잡한 데이터 변환/계산
 - 여러 store 조합 로직
 
 **분리 기준:**
 
-- 로직이 길어지면 → `model/` composables로 추출
+- 로직이 길어지면 → `model/` 커스텀 Hook으로 추출
 - 재사용 가능한 계산 → `shared/lib/`로 추출
 - 상태 공유 필요 → `*.store.ts`로 이동
 - 서버 데이터 → `use*Query.ts`로 이동
 
-### Composable 네이밍 (강제)
+### Hook 네이밍 (강제)
 
 - `use` prefix 필수
 - 예: `useUsers`, `useUserDetail`, `useUsersQuery`
+
+### React 성능 최적화 규칙 (권장)
+
+```tsx
+// ✅ 무거운 계산은 useMemo
+const filteredUsers = useMemo(
+  () => users.filter((u) => u.name.includes(keyword)),
+  [users, keyword]
+)
+
+// ✅ 자식에게 전달하는 콜백은 useCallback
+const handleSelect = useCallback((id: number) => {
+  setSelectedId(id)
+}, [])
+
+// ✅ 리스트 렌더링 시 key prop 필수 (index 사용 금지)
+{users.map((user) => (
+  <UserCard key={user.id} user={user} />
+))}
+
+// ❌ 불필요한 useMemo/useCallback 남용 금지
+// 단순한 값이나 컴포넌트 내부에서만 쓰는 함수는 그대로 사용
+```
 
 ---
 
@@ -396,12 +549,25 @@ Vue 파일은 다음 역할만 담당:
 | 위치                       | 권장                 |
 | -------------------------- | -------------------- |
 | `shared/lib/`, `**/model/` | function declaration |
-| component 내부             | arrow function       |
+| 컴포넌트                   | function declaration |
+| 이벤트 핸들러, 콜백        | arrow function       |
 
 ### interface vs type (강제)
 
-- 객체 구조 / 확장 목적 → `interface`
+- 객체 구조 / 확장 목적 / Props → `interface`
 - 유니온 / 튜플 / 조합 타입 → `type`
+
+```typescript
+// ✅ Props는 interface
+interface AppButtonProps {
+  variant: 'primary' | 'secondary' | 'outline'
+  disabled?: boolean
+  children: React.ReactNode
+}
+
+// ✅ 유니온은 type
+type ButtonVariant = 'primary' | 'secondary' | 'outline'
+```
 
 ### any 사용 금지 (강제)
 
@@ -453,20 +619,20 @@ export async function getUserById(userId: number): Promise<ApiResponse<User>> {
 src/
 ├── shared/ui/
 │   └── AppButton/
-│       ├── AppButton.vue
-│       └── AppButton.stories.ts    # ✅ 컴포넌트 옆에 배치
+│       ├── AppButton.tsx
+│       └── AppButton.stories.tsx    # ✅ 컴포넌트 옆에 배치
 ├── entities/user/ui/
 │   └── UserCard/
-│       ├── UserCard.vue
-│       └── UserCard.stories.ts
+│       ├── UserCard.tsx
+│       └── UserCard.stories.tsx
 ├── features/auth/ui/
 │   └── LoginForm/
-│       ├── LoginForm.vue
-│       └── LoginForm.stories.ts
+│       ├── LoginForm.tsx
+│       └── LoginForm.stories.tsx
 └── widgets/
     └── Header/
-        ├── Header.vue
-        └── Header.stories.ts
+        ├── Header.tsx
+        └── Header.stories.tsx
 ```
 
 ### 스토리 네이밍 컨벤션
@@ -496,8 +662,8 @@ title: 'widgets/Header'
 각 스토리에 `parameters.docs.source.code`를 사용하여 실제 사용 예시를 명시합니다.
 
 ```typescript
-import type { Meta, StoryObj } from '@storybook/vue3-vite'
-import AppButton from './AppButton.vue'
+import type { Meta, StoryObj } from '@storybook/react'
+import { AppButton } from './AppButton'
 
 const meta: Meta<typeof AppButton> = {
   title: 'shared/ui/atoms/AppButton',
@@ -522,7 +688,7 @@ type Story = StoryObj<typeof AppButton>
 export const Primary: Story = {
   args: {
     variant: 'primary',
-    default: '확인'
+    children: '확인'
   },
   parameters: {
     docs: {
@@ -536,7 +702,7 @@ export const Primary: Story = {
 export const Secondary: Story = {
   args: {
     variant: 'secondary',
-    default: '취소'
+    children: '취소'
   },
   parameters: {
     docs: {
@@ -551,7 +717,7 @@ export const Disabled: Story = {
   args: {
     variant: 'primary',
     disabled: true,
-    default: '비활성화'
+    children: '비활성화'
   },
   parameters: {
     docs: {
@@ -567,24 +733,18 @@ export const WithIcon: Story = {
   args: {
     variant: 'primary'
   },
-  render: (args) => ({
-    components: { AppButton },
-    setup() {
-      return { args }
-    },
-    template: `
-      <AppButton v-bind="args">
-        <template #icon>🔍</template>
-        검색
-      </AppButton>
-    `
-  }),
+  render: (args) => (
+    <AppButton {...args}>
+      <span>🔍</span>
+      검색
+    </AppButton>
+  ),
   parameters: {
     docs: {
       source: {
         code: `
 <AppButton variant="primary">
-  <template #icon>🔍</template>
+  <span>🔍</span>
   검색
 </AppButton>
         `.trim()
@@ -649,7 +809,7 @@ src/entities/user/model/
 
 **테스트 대상 우선순위**:
 
-1. composables (비즈니스 로직)
+1. 커스텀 Hooks (비즈니스 로직)
 2. store (상태 관리)
 3. utils (유틸리티 함수)
 4. API 함수
@@ -667,22 +827,26 @@ npm run test:coverage  # 커버리지 리포트
 ```typescript
 // entities/user/model/useUsers.spec.ts
 import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { useUsers } from './useUsers'
 
 describe('useUsers', () => {
   it('초기 상태에서 users는 빈 배열이어야 한다', () => {
-    const { users } = useUsers()
-    expect(users.value).toEqual([])
+    const { result } = renderHook(() => useUsers())
+    expect(result.current.users).toEqual([])
   })
 
   it('fetchUsers 호출 시 loading이 true가 되어야 한다', async () => {
-    const { loading, fetchUsers } = useUsers()
+    const { result } = renderHook(() => useUsers())
 
-    const fetchPromise = fetchUsers()
-    expect(loading.value).toBe(true)
+    act(() => {
+      result.current.fetchUsers()
+    })
+    expect(result.current.loading).toBe(true)
 
-    await fetchPromise
-    expect(loading.value).toBe(false)
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
   })
 })
 ```
@@ -742,9 +906,9 @@ test.describe('사용자 목록', () => {
 
 ### 테스트 우선순위
 
-| 우선순위 | 대상                                | 도구               |
-| -------- | ----------------------------------- | ------------------ |
-| 1        | 비즈니스 로직 (composables, stores) | Vitest             |
-| 2        | 유틸리티 함수                       | Vitest             |
-| 3        | 핵심 사용자 플로우                  | Playwright         |
-| 4        | 컴포넌트 렌더링/인터랙션            | Storybook + Vitest |
+| 우선순위 | 대상                                    | 도구               |
+| -------- | --------------------------------------- | ------------------ |
+| 1        | 비즈니스 로직 (커스텀 Hooks, stores)    | Vitest             |
+| 2        | 유틸리티 함수                           | Vitest             |
+| 3        | 핵심 사용자 플로우                      | Playwright         |
+| 4        | 컴포넌트 렌더링/인터랙션                | Storybook + Vitest |

--- a/Template-Tester_FE/package-lock.json
+++ b/Template-Tester_FE/package-lock.json
@@ -21,8 +21,12 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.58.2",
         "@storybook/react": "^10.2.7",
         "@storybook/react-vite": "^10.2.7",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -32,14 +36,23 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^28.1.0",
         "postcss": "^8.4.49",
         "storybook": "^10.2.7",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^7.2.4",
-        "vite-plugin-pages": "^0.33.2"
+        "vite-plugin-pages": "^0.33.2",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -60,6 +73,64 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -301,7 +372,6 @@
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -352,6 +422,151 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -951,6 +1166,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/ai": {
@@ -1829,6 +2062,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2231,6 +2480,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@storybook/builder-vite": {
       "version": "10.2.7",
       "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.2.7.tgz",
@@ -2421,6 +2677,34 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
@@ -2896,6 +3180,53 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
@@ -2907,6 +3238,95 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/spy": {
@@ -2958,6 +3378,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3135,6 +3565,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -3447,6 +3887,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -3467,12 +3921,52 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.1.0.tgz",
+      "integrity": "sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3491,6 +3985,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3629,6 +4130,26 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -3910,6 +4431,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -4306,11 +4837,52 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/idb": {
       "version": "7.1.1",
@@ -4471,6 +5043,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
@@ -4538,6 +5117,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4743,6 +5363,13 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4959,6 +5586,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/open": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -5056,6 +5694,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -5179,6 +5830,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -5647,6 +6345,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -5788,6 +6496,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5833,6 +6554,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5866,10 +6594,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/storybook": {
@@ -6032,6 +6774,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -6110,6 +6859,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6147,6 +6913,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6158,6 +6944,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6268,6 +7080,16 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -6490,11 +7312,187 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
@@ -6526,6 +7524,31 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6540,6 +7563,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -6606,6 +7646,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/Template-Tester_FE/package.json
+++ b/Template-Tester_FE/package.json
@@ -9,7 +9,12 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
@@ -25,8 +30,12 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.58.2",
     "@storybook/react": "^10.2.7",
     "@storybook/react-vite": "^10.2.7",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
@@ -36,12 +45,14 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^28.1.0",
     "postcss": "^8.4.49",
     "storybook": "^10.2.7",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4",
-    "vite-plugin-pages": "^0.33.2"
+    "vite-plugin-pages": "^0.33.2",
+    "vitest": "^4.0.18"
   }
 }

--- a/Template-Tester_FE/playwright.config.ts
+++ b/Template-Tester_FE/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/Template-Tester_FE/src/entities/friend/model/useFriendList.spec.ts
+++ b/Template-Tester_FE/src/entities/friend/model/useFriendList.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFriendList } from "./useFriendList";
+
+// --- Mocks ---
+
+const mockGetFriendList = vi.fn();
+const mockGetFriendshipStatus = vi.fn();
+const mockDeleteFriendship = vi.fn();
+
+vi.mock("../api/friend.api", () => ({
+  getFriendList: (...args: unknown[]) => mockGetFriendList(...args),
+  getFriendshipStatus: (...args: unknown[]) => mockGetFriendshipStatus(...args),
+  deleteFriendship: (...args: unknown[]) => mockDeleteFriendship(...args),
+}));
+
+const mockAlert = vi.fn();
+const mockConfirm = vi.fn();
+vi.stubGlobal("alert", mockAlert);
+vi.stubGlobal("confirm", mockConfirm);
+
+// --- Test Data ---
+
+const mockFriends = [
+  {
+    odUserId: "user1",
+    email: "friend1@test.com",
+    displayName: "친구1",
+    photoURL: null,
+  },
+  {
+    odUserId: "user2",
+    email: "friend2@test.com",
+    displayName: "친구2",
+    photoURL: null,
+  },
+];
+
+// --- Tests ---
+
+describe("useFriendList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("초기 상태", () => {
+    it("friends가 빈 배열이어야 한다", () => {
+      const { result } = renderHook(() => useFriendList());
+      expect(result.current.friends).toEqual([]);
+    });
+
+    it("isLoading이 false여야 한다", () => {
+      const { result } = renderHook(() => useFriendList());
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("loadFriendList", () => {
+    it("친구 목록을 로드해야 한다", async () => {
+      mockGetFriendList.mockResolvedValue(mockFriends);
+
+      const { result } = renderHook(() => useFriendList());
+
+      await act(async () => {
+        await result.current.loadFriendList();
+      });
+
+      expect(result.current.friends).toEqual(mockFriends);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("로드 실패 시 빈 배열을 유지해야 한다", async () => {
+      mockGetFriendList.mockRejectedValue(new Error("로드 실패"));
+
+      const { result } = renderHook(() => useFriendList());
+
+      await act(async () => {
+        await result.current.loadFriendList();
+      });
+
+      expect(result.current.friends).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("handleDeleteFriend", () => {
+    it("confirm 취소 시 삭제하지 않아야 한다", async () => {
+      mockConfirm.mockReturnValue(false);
+
+      const { result } = renderHook(() => useFriendList());
+
+      await act(async () => {
+        await result.current.handleDeleteFriend("user1");
+      });
+
+      expect(mockGetFriendshipStatus).not.toHaveBeenCalled();
+    });
+
+    it("confirm 확인 시 friendship 상태 확인 후 삭제해야 한다", async () => {
+      mockConfirm.mockReturnValue(true);
+      mockGetFriendshipStatus.mockResolvedValue({ id: "fs-1" });
+      mockDeleteFriendship.mockResolvedValue(undefined);
+      mockGetFriendList.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useFriendList());
+
+      await act(async () => {
+        await result.current.handleDeleteFriend("user1");
+      });
+
+      expect(mockGetFriendshipStatus).toHaveBeenCalledWith("user1");
+      expect(mockDeleteFriendship).toHaveBeenCalledWith("fs-1");
+      expect(mockAlert).toHaveBeenCalledWith("친구를 삭제했습니다.");
+    });
+
+    it("삭제 실패 시 alert을 표시해야 한다", async () => {
+      mockConfirm.mockReturnValue(true);
+      mockGetFriendshipStatus.mockRejectedValue(new Error("실패"));
+
+      const { result } = renderHook(() => useFriendList());
+
+      await act(async () => {
+        await result.current.handleDeleteFriend("user1");
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("친구 삭제에 실패했습니다.");
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/friend/model/useFriendList.ts
+++ b/Template-Tester_FE/src/entities/friend/model/useFriendList.ts
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import {
+  getFriendList,
+  getFriendshipStatus,
+  deleteFriendship,
+} from "../api/friend.api";
+import type { FriendInfo } from "./friend.type";
+
+export function useFriendList() {
+  const [friends, setFriends] = useState<FriendInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadFriendList = async () => {
+    setIsLoading(true);
+    try {
+      const data = await getFriendList();
+      setFriends(data);
+    } catch (error) {
+      console.error("친구 목록 로드 실패:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDeleteFriend = async (friendUserId: string) => {
+    if (!confirm("정말 이 친구를 삭제하시겠습니까?")) return;
+
+    try {
+      const status = await getFriendshipStatus(friendUserId);
+      if (status?.id) {
+        await deleteFriendship(status.id);
+        alert("친구를 삭제했습니다.");
+        loadFriendList();
+      }
+    } catch (error) {
+      console.error("친구 삭제 실패:", error);
+      alert("친구 삭제에 실패했습니다.");
+    }
+  };
+
+  return {
+    friends,
+    isLoading,
+    loadFriendList,
+    handleDeleteFriend,
+  };
+}

--- a/Template-Tester_FE/src/entities/friend/model/useFriendRequests.spec.ts
+++ b/Template-Tester_FE/src/entities/friend/model/useFriendRequests.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFriendRequests } from "./useFriendRequests";
+
+// --- Mocks ---
+
+const mockGetReceivedFriendRequests = vi.fn();
+const mockGetSentFriendRequests = vi.fn();
+const mockAcceptFriendRequest = vi.fn();
+const mockRejectFriendRequest = vi.fn();
+const mockDeleteFriendship = vi.fn();
+
+vi.mock("../api/friend.api", () => ({
+  getReceivedFriendRequests: (...args: unknown[]) =>
+    mockGetReceivedFriendRequests(...args),
+  getSentFriendRequests: (...args: unknown[]) =>
+    mockGetSentFriendRequests(...args),
+  acceptFriendRequest: (...args: unknown[]) =>
+    mockAcceptFriendRequest(...args),
+  rejectFriendRequest: (...args: unknown[]) =>
+    mockRejectFriendRequest(...args),
+  deleteFriendship: (...args: unknown[]) =>
+    mockDeleteFriendship(...args),
+}));
+
+const mockAlert = vi.fn();
+vi.stubGlobal("alert", mockAlert);
+
+// --- Test Data ---
+
+const mockReceived = [
+  {
+    id: "fr-1",
+    requesterId: "user-a",
+    requesterEmail: "a@test.com",
+    requesterDisplayName: "UserA",
+    requesterPhotoURL: null,
+    receiverId: "me",
+    receiverEmail: "me@test.com",
+    receiverDisplayName: "Me",
+    receiverPhotoURL: null,
+    status: "pending" as const,
+    createdAt: new Date(),
+  },
+];
+
+const mockSent = [
+  {
+    id: "fr-2",
+    requesterId: "me",
+    requesterEmail: "me@test.com",
+    requesterDisplayName: "Me",
+    requesterPhotoURL: null,
+    receiverId: "user-b",
+    receiverEmail: "b@test.com",
+    receiverDisplayName: "UserB",
+    receiverPhotoURL: null,
+    status: "pending" as const,
+    createdAt: new Date(),
+  },
+];
+
+// --- Tests ---
+
+describe("useFriendRequests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("초기 상태", () => {
+    it("받은/보낸 요청이 빈 배열이어야 한다", () => {
+      const { result } = renderHook(() => useFriendRequests());
+      expect(result.current.receivedRequests).toEqual([]);
+      expect(result.current.sentRequests).toEqual([]);
+    });
+  });
+
+  describe("loadRequests", () => {
+    it("받은 요청과 보낸 요청을 동시에 로드해야 한다", async () => {
+      mockGetReceivedFriendRequests.mockResolvedValue(mockReceived);
+      mockGetSentFriendRequests.mockResolvedValue(mockSent);
+
+      const { result } = renderHook(() => useFriendRequests());
+
+      await act(async () => {
+        await result.current.loadRequests();
+      });
+
+      expect(result.current.receivedRequests).toEqual(mockReceived);
+      expect(result.current.sentRequests).toEqual(mockSent);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("로드 실패 시 빈 배열을 유지해야 한다", async () => {
+      mockGetReceivedFriendRequests.mockRejectedValue(new Error("실패"));
+
+      const { result } = renderHook(() => useFriendRequests());
+
+      await act(async () => {
+        await result.current.loadRequests();
+      });
+
+      expect(result.current.receivedRequests).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("handleAccept", () => {
+    it("수락 성공 시 alert을 표시하고 목록을 새로고침해야 한다", async () => {
+      mockAcceptFriendRequest.mockResolvedValue(undefined);
+      mockGetReceivedFriendRequests.mockResolvedValue([]);
+      mockGetSentFriendRequests.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useFriendRequests());
+
+      await act(async () => {
+        await result.current.handleAccept("fr-1");
+      });
+
+      expect(mockAcceptFriendRequest).toHaveBeenCalledWith("fr-1");
+      expect(mockAlert).toHaveBeenCalledWith("친구 요청을 수락했습니다.");
+    });
+
+    it("수락 실패 시 에러 alert을 표시해야 한다", async () => {
+      mockAcceptFriendRequest.mockRejectedValue(new Error("실패"));
+
+      const { result } = renderHook(() => useFriendRequests());
+
+      await act(async () => {
+        await result.current.handleAccept("fr-1");
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith(
+        "친구 요청 수락에 실패했습니다.",
+      );
+    });
+  });
+
+  describe("handleReject", () => {
+    it("거절 성공 시 alert을 표시해야 한다", async () => {
+      mockRejectFriendRequest.mockResolvedValue(undefined);
+      mockGetReceivedFriendRequests.mockResolvedValue([]);
+      mockGetSentFriendRequests.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useFriendRequests());
+
+      await act(async () => {
+        await result.current.handleReject("fr-1");
+      });
+
+      expect(mockRejectFriendRequest).toHaveBeenCalledWith("fr-1");
+      expect(mockAlert).toHaveBeenCalledWith("친구 요청을 거절했습니다.");
+    });
+
+    it("거절 실패 시 에러 alert을 표시해야 한다", async () => {
+      mockRejectFriendRequest.mockRejectedValue(new Error("실패"));
+
+      const { result } = renderHook(() => useFriendRequests());
+
+      await act(async () => {
+        await result.current.handleReject("fr-1");
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith(
+        "친구 요청 거절에 실패했습니다.",
+      );
+    });
+  });
+
+  describe("handleCancelRequest", () => {
+    it("취소 성공 시 alert을 표시해야 한다", async () => {
+      mockDeleteFriendship.mockResolvedValue(undefined);
+      mockGetReceivedFriendRequests.mockResolvedValue([]);
+      mockGetSentFriendRequests.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useFriendRequests());
+
+      await act(async () => {
+        await result.current.handleCancelRequest("fr-2");
+      });
+
+      expect(mockDeleteFriendship).toHaveBeenCalledWith("fr-2");
+      expect(mockAlert).toHaveBeenCalledWith("친구 요청을 취소했습니다.");
+    });
+
+    it("취소 실패 시 에러 alert을 표시해야 한다", async () => {
+      mockDeleteFriendship.mockRejectedValue(new Error("실패"));
+
+      const { result } = renderHook(() => useFriendRequests());
+
+      await act(async () => {
+        await result.current.handleCancelRequest("fr-2");
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith(
+        "친구 요청 취소에 실패했습니다.",
+      );
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/friend/model/useFriendRequests.ts
+++ b/Template-Tester_FE/src/entities/friend/model/useFriendRequests.ts
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import {
+  getReceivedFriendRequests,
+  getSentFriendRequests,
+  acceptFriendRequest,
+  rejectFriendRequest,
+  deleteFriendship,
+} from "../api/friend.api";
+import type { Friendship } from "./friend.type";
+
+export function useFriendRequests() {
+  const [receivedRequests, setReceivedRequests] = useState<Friendship[]>([]);
+  const [sentRequests, setSentRequests] = useState<Friendship[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadRequests = async () => {
+    setIsLoading(true);
+    try {
+      const [received, sent] = await Promise.all([
+        getReceivedFriendRequests(),
+        getSentFriendRequests(),
+      ]);
+      setReceivedRequests(received);
+      setSentRequests(sent);
+    } catch (error) {
+      console.error("친구 요청 로드 실패:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleAccept = async (friendshipId: string) => {
+    try {
+      await acceptFriendRequest(friendshipId);
+      alert("친구 요청을 수락했습니다.");
+      loadRequests();
+    } catch (error) {
+      console.error("친구 수락 실패:", error);
+      alert("친구 요청 수락에 실패했습니다.");
+    }
+  };
+
+  const handleReject = async (friendshipId: string) => {
+    try {
+      await rejectFriendRequest(friendshipId);
+      alert("친구 요청을 거절했습니다.");
+      loadRequests();
+    } catch (error) {
+      console.error("친구 거절 실패:", error);
+      alert("친구 요청 거절에 실패했습니다.");
+    }
+  };
+
+  const handleCancelRequest = async (friendshipId: string) => {
+    try {
+      await deleteFriendship(friendshipId);
+      alert("친구 요청을 취소했습니다.");
+      loadRequests();
+    } catch (error) {
+      console.error("요청 취소 실패:", error);
+      alert("친구 요청 취소에 실패했습니다.");
+    }
+  };
+
+  return {
+    receivedRequests,
+    sentRequests,
+    isLoading,
+    loadRequests,
+    handleAccept,
+    handleReject,
+    handleCancelRequest,
+  };
+}

--- a/Template-Tester_FE/src/entities/friend/model/useFriendSearch.spec.ts
+++ b/Template-Tester_FE/src/entities/friend/model/useFriendSearch.spec.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFriendSearch } from "./useFriendSearch";
+
+// --- Mocks ---
+
+const mockSendFriendRequest = vi.fn();
+const mockGetFriendshipStatus = vi.fn();
+
+vi.mock("../api/friend.api", () => ({
+  sendFriendRequest: (...args: unknown[]) => mockSendFriendRequest(...args),
+  getFriendshipStatus: (...args: unknown[]) =>
+    mockGetFriendshipStatus(...args),
+}));
+
+const mockSearchUserByDisplayName = vi.fn();
+
+vi.mock("@/entities/user/api/user.api", () => ({
+  searchUserByDisplayName: (...args: unknown[]) =>
+    mockSearchUserByDisplayName(...args),
+}));
+
+const mockAlert = vi.fn();
+vi.stubGlobal("alert", mockAlert);
+
+// --- Test Data ---
+
+const mockUsers = [
+  { uid: "u1", email: "user1@test.com", displayName: "테스터1", photoURL: null },
+  { uid: "u2", email: "user2@test.com", displayName: "테스터2", photoURL: null },
+];
+
+// --- Tests ---
+
+describe("useFriendSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("초기 상태", () => {
+    it("검색어가 빈 문자열이어야 한다", () => {
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+      expect(result.current.searchQuery).toBe("");
+    });
+
+    it("검색 결과가 빈 배열이어야 한다", () => {
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+      expect(result.current.searchResults).toEqual([]);
+    });
+
+    it("isSearching이 false여야 한다", () => {
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+      expect(result.current.isSearching).toBe(false);
+    });
+  });
+
+  describe("handleSearch", () => {
+    it("검색어가 비어있으면 검색하지 않아야 한다", async () => {
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      await act(async () => {
+        await result.current.handleSearch();
+      });
+
+      expect(mockSearchUserByDisplayName).not.toHaveBeenCalled();
+    });
+
+    it("검색어가 공백만이면 검색하지 않아야 한다", async () => {
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      act(() => {
+        result.current.setSearchQuery("   ");
+      });
+
+      await act(async () => {
+        await result.current.handleSearch();
+      });
+
+      expect(mockSearchUserByDisplayName).not.toHaveBeenCalled();
+    });
+
+    it("검색 성공 시 결과와 상태를 업데이트해야 한다", async () => {
+      mockSearchUserByDisplayName.mockResolvedValue(mockUsers);
+      mockGetFriendshipStatus.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      act(() => {
+        result.current.setSearchQuery("테스터");
+      });
+
+      await act(async () => {
+        await result.current.handleSearch();
+      });
+
+      expect(mockSearchUserByDisplayName).toHaveBeenCalledWith("테스터");
+      expect(result.current.searchResults).toEqual(mockUsers);
+      expect(result.current.isSearching).toBe(false);
+    });
+
+    it("검색 실패 시 alert을 표시해야 한다", async () => {
+      mockSearchUserByDisplayName.mockRejectedValue(new Error("검색 실패"));
+
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      act(() => {
+        result.current.setSearchQuery("테스터");
+      });
+
+      await act(async () => {
+        await result.current.handleSearch();
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("사용자 검색에 실패했습니다.");
+    });
+  });
+
+  describe("handleSendRequest", () => {
+    it("요청 성공 시 alert을 표시하고 상태를 업데이트해야 한다", async () => {
+      mockSendFriendRequest.mockResolvedValue(undefined);
+      mockGetFriendshipStatus.mockResolvedValue({
+        status: "pending",
+        requesterId: "my-id",
+      });
+
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      await act(async () => {
+        await result.current.handleSendRequest("u1");
+      });
+
+      expect(mockSendFriendRequest).toHaveBeenCalledWith("u1");
+      expect(mockAlert).toHaveBeenCalledWith("친구 요청을 보냈습니다.");
+    });
+
+    it("요청 실패 시 에러 메시지를 alert으로 표시해야 한다", async () => {
+      mockSendFriendRequest.mockRejectedValue(
+        new Error("이미 요청된 사용자입니다."),
+      );
+
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      await act(async () => {
+        await result.current.handleSendRequest("u1");
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("이미 요청된 사용자입니다.");
+    });
+  });
+
+  describe("getRequestButtonText", () => {
+    it("상태가 없으면 '친구 요청'을 반환해야 한다", () => {
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+      expect(result.current.getRequestButtonText("unknown")).toBe("친구 요청");
+    });
+
+    it("accepted 상태면 '이미 친구'를 반환해야 한다", async () => {
+      mockSearchUserByDisplayName.mockResolvedValue(mockUsers);
+      mockGetFriendshipStatus.mockResolvedValue({ status: "accepted" });
+
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      act(() => {
+        result.current.setSearchQuery("테스터");
+      });
+
+      await act(async () => {
+        await result.current.handleSearch();
+      });
+
+      expect(result.current.getRequestButtonText("u1")).toBe("이미 친구");
+    });
+
+    it("pending + 내가 보낸 요청이면 '요청 보냄'을 반환해야 한다", async () => {
+      mockSearchUserByDisplayName.mockResolvedValue([mockUsers[0]]);
+      mockGetFriendshipStatus.mockResolvedValue({
+        status: "pending",
+        requesterId: "my-id",
+      });
+
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      act(() => {
+        result.current.setSearchQuery("테스터");
+      });
+
+      await act(async () => {
+        await result.current.handleSearch();
+      });
+
+      expect(result.current.getRequestButtonText("u1")).toBe("요청 보냄");
+    });
+
+    it("pending + 상대가 보낸 요청이면 '요청 받음'을 반환해야 한다", async () => {
+      mockSearchUserByDisplayName.mockResolvedValue([mockUsers[0]]);
+      mockGetFriendshipStatus.mockResolvedValue({
+        status: "pending",
+        requesterId: "u1",
+      });
+
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      act(() => {
+        result.current.setSearchQuery("테스터");
+      });
+
+      await act(async () => {
+        await result.current.handleSearch();
+      });
+
+      expect(result.current.getRequestButtonText("u1")).toBe("요청 받음");
+    });
+  });
+
+  describe("isRequestDisabled", () => {
+    it("상태가 없으면 false여야 한다", () => {
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+      expect(result.current.isRequestDisabled("unknown")).toBe(false);
+    });
+
+    it("accepted 상태면 true여야 한다", async () => {
+      mockSearchUserByDisplayName.mockResolvedValue([mockUsers[0]]);
+      mockGetFriendshipStatus.mockResolvedValue({ status: "accepted" });
+
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      act(() => {
+        result.current.setSearchQuery("테스터");
+      });
+
+      await act(async () => {
+        await result.current.handleSearch();
+      });
+
+      expect(result.current.isRequestDisabled("u1")).toBe(true);
+    });
+
+    it("pending 상태면 true여야 한다", async () => {
+      mockSearchUserByDisplayName.mockResolvedValue([mockUsers[0]]);
+      mockGetFriendshipStatus.mockResolvedValue({
+        status: "pending",
+        requesterId: "my-id",
+      });
+
+      const { result } = renderHook(() => useFriendSearch("my-id"));
+
+      act(() => {
+        result.current.setSearchQuery("테스터");
+      });
+
+      await act(async () => {
+        await result.current.handleSearch();
+      });
+
+      expect(result.current.isRequestDisabled("u1")).toBe(true);
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/friend/model/useFriendSearch.ts
+++ b/Template-Tester_FE/src/entities/friend/model/useFriendSearch.ts
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { sendFriendRequest, getFriendshipStatus } from "../api/friend.api";
+import { searchUserByDisplayName } from "@/entities/user/api/user.api";
+import type { Friendship } from "./friend.type";
+import type { UserProfile } from "@/entities/user/model/user.type";
+
+export function useFriendSearch(currentUserId?: string) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<UserProfile[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchedUserStatuses, setSearchedUserStatuses] = useState<
+    Record<string, Friendship | null>
+  >({});
+
+  const handleSearch = async () => {
+    if (!searchQuery.trim()) return;
+
+    setIsSearching(true);
+    try {
+      const results = await searchUserByDisplayName(searchQuery.trim());
+      setSearchResults(results);
+
+      const statuses: Record<string, Friendship | null> = {};
+      for (const user of results) {
+        const status = await getFriendshipStatus(user.uid);
+        statuses[user.uid] = status;
+      }
+      setSearchedUserStatuses(statuses);
+    } catch (error) {
+      console.error("사용자 검색 실패:", error);
+      alert("사용자 검색에 실패했습니다.");
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const handleSendRequest = async (receiverUserId: string) => {
+    try {
+      await sendFriendRequest(receiverUserId);
+      alert("친구 요청을 보냈습니다.");
+      const status = await getFriendshipStatus(receiverUserId);
+      setSearchedUserStatuses((prev) => ({
+        ...prev,
+        [receiverUserId]: status,
+      }));
+    } catch (error: unknown) {
+      console.error("친구 요청 실패:", error);
+      const message = error instanceof Error ? error.message : "친구 요청에 실패했습니다.";
+      alert(message);
+    }
+  };
+
+  const getRequestButtonText = (userId: string): string => {
+    const status = searchedUserStatuses[userId];
+    if (!status) return "친구 요청";
+    if (status.status === "accepted") return "이미 친구";
+    if (status.status === "pending") {
+      if (status.requesterId === currentUserId) return "요청 보냄";
+      return "요청 받음";
+    }
+    return "친구 요청";
+  };
+
+  const isRequestDisabled = (userId: string): boolean => {
+    const status = searchedUserStatuses[userId];
+    if (!status) return false;
+    return status.status === "accepted" || status.status === "pending";
+  };
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    searchResults,
+    isSearching,
+    handleSearch,
+    handleSendRequest,
+    getRequestButtonText,
+    isRequestDisabled,
+  };
+}

--- a/Template-Tester_FE/src/entities/friend/model/usePendingRequestCount.spec.ts
+++ b/Template-Tester_FE/src/entities/friend/model/usePendingRequestCount.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
 import { usePendingRequestCount } from "./usePendingRequestCount";
 
 // --- Mocks ---

--- a/Template-Tester_FE/src/entities/friend/model/usePendingRequestCount.spec.ts
+++ b/Template-Tester_FE/src/entities/friend/model/usePendingRequestCount.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { usePendingRequestCount } from "./usePendingRequestCount";
+
+// --- Mocks ---
+
+const mockGetReceivedFriendRequests = vi.fn();
+
+vi.mock("../api/friend.api", () => ({
+  getReceivedFriendRequests: (...args: unknown[]) =>
+    mockGetReceivedFriendRequests(...args),
+}));
+
+// --- Tests ---
+
+describe("usePendingRequestCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("로그인 상태가 아니면 요청을 보내지 않아야 한다", () => {
+    renderHook(() => usePendingRequestCount(false));
+    expect(mockGetReceivedFriendRequests).not.toHaveBeenCalled();
+  });
+
+  it("로그인 상태이면 즉시 요청 수를 로드해야 한다", async () => {
+    mockGetReceivedFriendRequests.mockResolvedValue([
+      { id: "1" },
+      { id: "2" },
+      { id: "3" },
+    ]);
+
+    const { result } = renderHook(() => usePendingRequestCount(true));
+
+    await waitFor(() => {
+      expect(result.current.pendingRequestCount).toBe(3);
+    });
+  });
+
+  it("API 에러 시 count를 0으로 유지해야 한다", async () => {
+    mockGetReceivedFriendRequests.mockRejectedValue(new Error("에러"));
+
+    const { result } = renderHook(() => usePendingRequestCount(true));
+
+    await waitFor(() => {
+      expect(mockGetReceivedFriendRequests).toHaveBeenCalled();
+    });
+
+    expect(result.current.pendingRequestCount).toBe(0);
+  });
+
+  it("언마운트 시 interval을 정리해야 한다", async () => {
+    mockGetReceivedFriendRequests.mockResolvedValue([{ id: "1" }]);
+
+    const { unmount } = renderHook(() => usePendingRequestCount(true));
+
+    await waitFor(() => {
+      expect(mockGetReceivedFriendRequests).toHaveBeenCalledTimes(1);
+    });
+
+    // clearInterval이 호출되는지 확인 (언마운트 시 cleanup)
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/Template-Tester_FE/src/entities/friend/model/usePendingRequestCount.ts
+++ b/Template-Tester_FE/src/entities/friend/model/usePendingRequestCount.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+import { getReceivedFriendRequests } from "../api/friend.api";
+
+export function usePendingRequestCount(isLoggedIn: boolean) {
+  const [pendingRequestCount, setPendingRequestCount] = useState(0);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+
+    const loadPendingRequests = async () => {
+      try {
+        const requests = await getReceivedFriendRequests();
+        setPendingRequestCount(requests.length);
+      } catch (error) {
+        console.error("친구 요청 수 로드 실패:", error);
+      }
+    };
+
+    loadPendingRequests();
+    const interval = setInterval(loadPendingRequests, 30000);
+    return () => clearInterval(interval);
+  }, [isLoggedIn]);
+
+  return { pendingRequestCount };
+}

--- a/Template-Tester_FE/src/entities/template/model/useMyTemplates.spec.ts
+++ b/Template-Tester_FE/src/entities/template/model/useMyTemplates.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMyTemplates } from "./useMyTemplates";
+
+// --- Mocks ---
+
+const mockGetUserTemplatesByCategory = vi.fn();
+const mockDeleteUserTemplate = vi.fn();
+
+vi.mock("../api/template.api", () => ({
+  getUserTemplatesByCategory: (...args: unknown[]) =>
+    mockGetUserTemplatesByCategory(...args),
+  deleteUserTemplate: (...args: unknown[]) =>
+    mockDeleteUserTemplate(...args),
+}));
+
+const mockAlert = vi.fn();
+const mockConfirm = vi.fn();
+vi.stubGlobal("alert", mockAlert);
+vi.stubGlobal("confirm", mockConfirm);
+
+// --- Test Data ---
+
+const mockTemplates = [
+  {
+    id: "1",
+    category: "algorithm" as const,
+    title: "버블 정렬",
+    description: "정렬 알고리즘",
+    answer: "answer1",
+  },
+  {
+    id: "2",
+    category: "algorithm" as const,
+    title: "이진 탐색",
+    description: "탐색 알고리즘",
+    answer: "answer2",
+  },
+];
+
+// --- Tests ---
+
+describe("useMyTemplates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("초기 상태", () => {
+    it("templates가 빈 배열이어야 한다", () => {
+      const { result } = renderHook(() => useMyTemplates());
+      expect(result.current.templates).toEqual([]);
+    });
+
+    it("isLoading이 true여야 한다", () => {
+      const { result } = renderHook(() => useMyTemplates());
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  describe("loadTemplates", () => {
+    it("템플릿 목록을 로드해야 한다", async () => {
+      mockGetUserTemplatesByCategory.mockResolvedValue(mockTemplates);
+
+      const { result } = renderHook(() => useMyTemplates());
+
+      await act(async () => {
+        await result.current.loadTemplates();
+      });
+
+      expect(result.current.templates).toEqual(mockTemplates);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("로드 실패 시 alert을 표시해야 한다", async () => {
+      mockGetUserTemplatesByCategory.mockRejectedValue(
+        new Error("로드 실패"),
+      );
+
+      const { result } = renderHook(() => useMyTemplates());
+
+      await act(async () => {
+        await result.current.loadTemplates();
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith(
+        "템플릿을 불러오는데 실패했습니다.",
+      );
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("handleDelete", () => {
+    it("confirm 취소 시 삭제하지 않아야 한다", async () => {
+      mockConfirm.mockReturnValue(false);
+
+      const { result } = renderHook(() => useMyTemplates());
+
+      await act(async () => {
+        await result.current.handleDelete("1", "버블 정렬");
+      });
+
+      expect(mockDeleteUserTemplate).not.toHaveBeenCalled();
+    });
+
+    it("confirm에 템플릿 제목이 포함되어야 한다", async () => {
+      mockConfirm.mockReturnValue(false);
+
+      const { result } = renderHook(() => useMyTemplates());
+
+      await act(async () => {
+        await result.current.handleDelete("1", "버블 정렬");
+      });
+
+      expect(mockConfirm).toHaveBeenCalledWith(
+        '"버블 정렬" 템플릿을 삭제하시겠습니까?',
+      );
+    });
+
+    it("삭제 성공 시 alert을 표시하고 목록을 새로고침해야 한다", async () => {
+      mockConfirm.mockReturnValue(true);
+      mockDeleteUserTemplate.mockResolvedValue(undefined);
+      mockGetUserTemplatesByCategory.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useMyTemplates());
+
+      await act(async () => {
+        await result.current.handleDelete("1", "버블 정렬");
+      });
+
+      expect(mockDeleteUserTemplate).toHaveBeenCalledWith("1");
+      expect(mockAlert).toHaveBeenCalledWith("템플릿이 삭제되었습니다.");
+    });
+
+    it("삭제 실패 시 에러 alert을 표시해야 한다", async () => {
+      mockConfirm.mockReturnValue(true);
+      mockDeleteUserTemplate.mockRejectedValue(new Error("삭제 실패"));
+
+      const { result } = renderHook(() => useMyTemplates());
+
+      await act(async () => {
+        await result.current.handleDelete("1", "버블 정렬");
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("템플릿 삭제에 실패했습니다.");
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/template/model/useMyTemplates.ts
+++ b/Template-Tester_FE/src/entities/template/model/useMyTemplates.ts
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import {
+  getUserTemplatesByCategory,
+  deleteUserTemplate,
+} from "../api/template.api";
+import type { Category, Template } from "./template.type";
+
+export function useMyTemplates() {
+  const [currentCategory] = useState<Category>("algorithm");
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadTemplates = async () => {
+    try {
+      setIsLoading(true);
+      const data = await getUserTemplatesByCategory(currentCategory);
+      setTemplates(data);
+    } catch (error) {
+      console.error("템플릿 로드 실패:", error);
+      alert("템플릿을 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDelete = async (templateId: string, title: string) => {
+    if (!confirm(`"${title}" 템플릿을 삭제하시겠습니까?`)) {
+      return;
+    }
+
+    try {
+      await deleteUserTemplate(templateId);
+      alert("템플릿이 삭제되었습니다.");
+      loadTemplates();
+    } catch (error) {
+      console.error("템플릿 삭제 실패:", error);
+      alert("템플릿 삭제에 실패했습니다.");
+    }
+  };
+
+  return {
+    templates,
+    isLoading,
+    loadTemplates,
+    handleDelete,
+  };
+}

--- a/Template-Tester_FE/src/entities/template/model/useTemplateForm.spec.ts
+++ b/Template-Tester_FE/src/entities/template/model/useTemplateForm.spec.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useTemplateForm } from "./useTemplateForm";
+
+// --- Mocks ---
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockGetUserTemplates = vi.fn();
+const mockSaveUserTemplate = vi.fn();
+const mockUpdateUserTemplate = vi.fn();
+
+vi.mock("../api/template.api", () => ({
+  getUserTemplates: (...args: unknown[]) => mockGetUserTemplates(...args),
+  saveUserTemplate: (...args: unknown[]) => mockSaveUserTemplate(...args),
+  updateUserTemplate: (...args: unknown[]) => mockUpdateUserTemplate(...args),
+}));
+
+// alert mock
+const mockAlert = vi.fn();
+vi.stubGlobal("alert", mockAlert);
+
+// --- Tests ---
+
+describe("useTemplateForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ===== 초기 상태 테스트 =====
+
+  describe("초기 상태 (생성 모드)", () => {
+    it("templateId가 없으면 isEditMode가 false여야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      expect(result.current.isEditMode).toBe(false);
+    });
+
+    it("기본 카테고리는 algorithm이어야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      expect(result.current.currentCategory).toBe("algorithm");
+    });
+
+    it("기본 templateType은 paragraph여야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      expect(result.current.templateType).toBe("paragraph");
+    });
+
+    it("title, description, answer가 빈 문자열이어야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      expect(result.current.title).toBe("");
+      expect(result.current.description).toBe("");
+      expect(result.current.answer).toBe("");
+    });
+
+    it("isSubmitting, isLoading이 false여야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      expect(result.current.isSubmitting).toBe(false);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  // ===== 편집 모드 테스트 =====
+
+  describe("편집 모드 (templateId 전달)", () => {
+    it("templateId가 있으면 isEditMode가 true여야 한다", () => {
+      mockGetUserTemplates.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useTemplateForm("test-id"));
+
+      expect(result.current.isEditMode).toBe(true);
+    });
+
+    it("편집 모드 진입 시 기존 템플릿 데이터를 로드해야 한다", async () => {
+      const mockTemplate = {
+        id: "test-id",
+        category: "english" as const,
+        title: "테스트 제목",
+        description: "테스트 설명",
+        answer: "테스트 답변",
+        type: "problem" as const,
+      };
+
+      mockGetUserTemplates.mockResolvedValue([mockTemplate]);
+
+      const { result } = renderHook(() => useTemplateForm("test-id"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.currentCategory).toBe("english");
+      expect(result.current.title).toBe("테스트 제목");
+      expect(result.current.description).toBe("테스트 설명");
+      expect(result.current.answer).toBe("테스트 답변");
+      expect(result.current.templateType).toBe("problem");
+    });
+
+    it("존재하지 않는 templateId일 경우 alert 후 홈으로 이동해야 한다", async () => {
+      mockGetUserTemplates.mockResolvedValue([]);
+
+      renderHook(() => useTemplateForm("nonexistent-id"));
+
+      await waitFor(() => {
+        expect(mockAlert).toHaveBeenCalledWith("템플릿을 찾을 수 없습니다.");
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith("/");
+    });
+
+    it("템플릿 로드 실패 시 에러 alert을 표시해야 한다", async () => {
+      mockGetUserTemplates.mockRejectedValue(new Error("네트워크 오류"));
+
+      renderHook(() => useTemplateForm("test-id"));
+
+      await waitFor(() => {
+        expect(mockAlert).toHaveBeenCalledWith(
+          "템플릿을 불러오는데 실패했습니다.",
+        );
+      });
+    });
+  });
+
+  // ===== 상태 변경 테스트 =====
+
+  describe("상태 변경 (setter)", () => {
+    it("setTitle로 제목을 변경할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setTitle("새 제목");
+      });
+
+      expect(result.current.title).toBe("새 제목");
+    });
+
+    it("setCurrentCategory로 카테고리를 변경할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setCurrentCategory("cs");
+      });
+
+      expect(result.current.currentCategory).toBe("cs");
+    });
+
+    it("setTemplateType으로 타입을 변경할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setTemplateType("problem");
+      });
+
+      expect(result.current.templateType).toBe("problem");
+    });
+  });
+
+  // ===== handleSubmit 테스트 =====
+
+  describe("handleSubmit", () => {
+    it("제목이 비어있으면 alert을 표시하고 제출하지 않아야 한다", async () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setAnswer("답변 있음");
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("템플릿 제목을 입력해주세요.");
+      expect(mockSaveUserTemplate).not.toHaveBeenCalled();
+    });
+
+    it("답변이 비어있으면 alert을 표시하고 제출하지 않아야 한다", async () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setTitle("제목 있음");
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("정답 내용을 입력해주세요.");
+      expect(mockSaveUserTemplate).not.toHaveBeenCalled();
+    });
+
+    it("생성 모드에서 saveUserTemplate을 호출해야 한다", async () => {
+      mockSaveUserTemplate.mockResolvedValue("new-id");
+
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setTitle("새 템플릿");
+        result.current.setDescription("설명");
+        result.current.setAnswer("정답");
+        result.current.setCurrentCategory("cs");
+        result.current.setTemplateType("problem");
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockSaveUserTemplate).toHaveBeenCalledWith(
+        "cs",
+        "새 템플릿",
+        "설명",
+        "정답",
+        "problem",
+      );
+      expect(mockAlert).toHaveBeenCalledWith(
+        "템플릿이 성공적으로 등록되었습니다!",
+      );
+      expect(mockNavigate).toHaveBeenCalledWith("/my-templates");
+    });
+
+    it("편집 모드에서 updateUserTemplate을 호출해야 한다", async () => {
+      const mockTemplate = {
+        id: "edit-id",
+        category: "algorithm" as const,
+        title: "기존 제목",
+        description: "기존 설명",
+        answer: "기존 답변",
+        type: "paragraph" as const,
+      };
+
+      mockGetUserTemplates.mockResolvedValue([mockTemplate]);
+      mockUpdateUserTemplate.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useTemplateForm("edit-id"));
+
+      await waitFor(() => {
+        expect(result.current.title).toBe("기존 제목");
+      });
+
+      act(() => {
+        result.current.setTitle("수정된 제목");
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockUpdateUserTemplate).toHaveBeenCalledWith(
+        "edit-id",
+        "algorithm",
+        "수정된 제목",
+        "기존 설명",
+        "기존 답변",
+        "paragraph",
+      );
+      expect(mockAlert).toHaveBeenCalledWith(
+        "템플릿이 성공적으로 수정되었습니다!",
+      );
+      expect(mockNavigate).toHaveBeenCalledWith("/my-templates");
+    });
+
+    it("저장 실패 시 에러 메시지를 alert으로 표시해야 한다", async () => {
+      mockSaveUserTemplate.mockRejectedValue(
+        new Error("저장 중 오류 발생"),
+      );
+
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setTitle("제목");
+        result.current.setAnswer("답변");
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("저장 중 오류 발생");
+      expect(mockNavigate).not.toHaveBeenCalledWith("/my-templates");
+    });
+
+    it("제출 중 isSubmitting이 true였다가 완료 후 false가 되어야 한다", async () => {
+      let resolvePromise: (value: string) => void;
+      mockSaveUserTemplate.mockImplementation(
+        () =>
+          new Promise<string>((resolve) => {
+            resolvePromise = resolve;
+          }),
+      );
+
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setTitle("제목");
+        result.current.setAnswer("답변");
+      });
+
+      let submitPromise: Promise<void>;
+      act(() => {
+        submitPromise = result.current.handleSubmit();
+      });
+
+      // 제출 중에는 isSubmitting이 true
+      expect(result.current.isSubmitting).toBe(true);
+
+      await act(async () => {
+        resolvePromise!("new-id");
+        await submitPromise!;
+      });
+
+      expect(result.current.isSubmitting).toBe(false);
+    });
+  });
+
+  // ===== handleReset 테스트 =====
+
+  describe("handleReset", () => {
+    it("폼 필드를 초기값으로 리셋해야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setTitle("입력된 제목");
+        result.current.setDescription("입력된 설명");
+        result.current.setAnswer("입력된 답변");
+        result.current.setTemplateType("problem");
+      });
+
+      expect(result.current.title).toBe("입력된 제목");
+
+      act(() => {
+        result.current.handleReset();
+      });
+
+      expect(result.current.title).toBe("");
+      expect(result.current.description).toBe("");
+      expect(result.current.answer).toBe("");
+      expect(result.current.templateType).toBe("paragraph");
+    });
+
+    it("카테고리는 리셋하지 않아야 한다", () => {
+      const { result } = renderHook(() => useTemplateForm());
+
+      act(() => {
+        result.current.setCurrentCategory("english");
+        result.current.setTitle("제목");
+      });
+
+      act(() => {
+        result.current.handleReset();
+      });
+
+      // 카테고리는 handleReset에 포함되지 않으므로 유지
+      expect(result.current.currentCategory).toBe("english");
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/template/model/useTemplateForm.ts
+++ b/Template-Tester_FE/src/entities/template/model/useTemplateForm.ts
@@ -1,0 +1,122 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  saveUserTemplate,
+  updateUserTemplate,
+  getUserTemplates,
+} from "../api/template.api";
+import type { Category, TemplateType } from "./template.type";
+
+export function useTemplateForm(templateId?: string | null) {
+  const navigate = useNavigate();
+  const isEditMode = !!templateId;
+
+  const [currentCategory, setCurrentCategory] = useState<Category>("algorithm");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [templateType, setTemplateType] = useState<TemplateType>("paragraph");
+  const [answer, setAnswer] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (isEditMode && templateId) {
+      loadTemplateData(templateId);
+    }
+  }, [isEditMode, templateId]);
+
+  const loadTemplateData = async (id: string) => {
+    try {
+      setIsLoading(true);
+      const templates = await getUserTemplates();
+      const template = templates.find((t) => t.id === id);
+
+      if (!template) {
+        alert("템플릿을 찾을 수 없습니다.");
+        navigate("/");
+        return;
+      }
+
+      setCurrentCategory(template.category);
+      setTitle(template.title);
+      setDescription(template.description || "");
+      setAnswer(template.answer);
+      setTemplateType(template.type || "paragraph");
+    } catch (error) {
+      console.error("템플릿 로드 실패:", error);
+      alert("템플릿을 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!title.trim()) {
+      alert("템플릿 제목을 입력해주세요.");
+      return;
+    }
+
+    if (!answer.trim()) {
+      alert("정답 내용을 입력해주세요.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+
+      if (isEditMode && templateId) {
+        await updateUserTemplate(
+          templateId,
+          currentCategory,
+          title,
+          description,
+          answer,
+          templateType,
+        );
+        alert("템플릿이 성공적으로 수정되었습니다!");
+      } else {
+        await saveUserTemplate(
+          currentCategory,
+          title,
+          description,
+          answer,
+          templateType,
+        );
+        alert("템플릿이 성공적으로 등록되었습니다!");
+      }
+
+      navigate("/my-templates");
+    } catch (error: unknown) {
+      console.error("템플릿 저장 실패:", error);
+      const message = error instanceof Error ? error.message : "템플릿 저장에 실패했습니다.";
+      alert(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleReset = () => {
+    setTitle("");
+    setDescription("");
+    setAnswer("");
+    setTemplateType("paragraph");
+  };
+
+  return {
+    currentCategory,
+    setCurrentCategory,
+    title,
+    setTitle,
+    description,
+    setDescription,
+    templateType,
+    setTemplateType,
+    answer,
+    setAnswer,
+    isSubmitting,
+    isLoading,
+    isEditMode,
+    handleSubmit,
+    handleReset,
+  };
+}

--- a/Template-Tester_FE/src/entities/wrong-note/model/useFriendWrongNotes.spec.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useFriendWrongNotes.spec.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFriendWrongNotes } from "./useFriendWrongNotes";
+import type { WrongNote, Filters } from "./wrong-note.type";
+
+// --- Mocks ---
+
+const mockGetFriendsSharedWrongNotes = vi.fn();
+
+vi.mock("../api/wrong-note.api", () => ({
+  getFriendsSharedWrongNotes: (...args: unknown[]) =>
+    mockGetFriendsSharedWrongNotes(...args),
+}));
+
+const mockGetFriendList = vi.fn();
+
+vi.mock("@/entities/friend/api/friend.api", () => ({
+  getFriendList: (...args: unknown[]) => mockGetFriendList(...args),
+}));
+
+// --- Test Data ---
+
+const mockFriendNotes: WrongNote[] = [
+  {
+    id: "fn1",
+    userId: "friend-1",
+    userEmail: "f1@test.com",
+    title: "친구의 DP 문제",
+    link: "https://programmers.co.kr/1",
+    language: "python",
+    category: "dp",
+    date: "2026-01-01",
+    platform: "programmers",
+    grade: "lv3",
+    myCode: "code1",
+    solution: "sol1",
+    comment: "",
+    share: true,
+    tags: ["algorithm_fail"],
+    result: "wrong",
+    createdAt: new Date("2026-01-01"),
+  },
+  {
+    id: "fn2",
+    userId: "friend-2",
+    userEmail: "f2@test.com",
+    title: "친구의 BFS 문제",
+    link: "https://baekjoon.com/2",
+    language: "java",
+    category: "bfs",
+    date: "2026-01-02",
+    platform: "baekjoon",
+    grade: "골드2",
+    myCode: "code2",
+    solution: "sol2",
+    comment: "",
+    share: true,
+    tags: [],
+    result: "timeout",
+    createdAt: new Date("2026-01-02"),
+  },
+];
+
+const mockFriends = [
+  {
+    odUserId: "friend-1",
+    email: "f1@test.com",
+    displayName: "친구일",
+    photoURL: null,
+  },
+  {
+    odUserId: "friend-2",
+    email: "f2@test.com",
+    displayName: null,
+    photoURL: null,
+  },
+];
+
+// --- Tests ---
+
+describe("useFriendWrongNotes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("초기 상태", () => {
+    it("friendNotes가 빈 배열이어야 한다", () => {
+      const { result } = renderHook(() => useFriendWrongNotes());
+      expect(result.current.friendNotes).toEqual([]);
+    });
+
+    it("friendFilter가 빈 문자열이어야 한다", () => {
+      const { result } = renderHook(() => useFriendWrongNotes());
+      expect(result.current.friendFilter).toBe("");
+    });
+  });
+
+  describe("loadFriendNotes", () => {
+    it("친구 오답노트와 친구 목록을 동시에 로드해야 한다", async () => {
+      mockGetFriendsSharedWrongNotes.mockResolvedValue(mockFriendNotes);
+      mockGetFriendList.mockResolvedValue(mockFriends);
+
+      const { result } = renderHook(() => useFriendWrongNotes());
+
+      await act(async () => {
+        await result.current.loadFriendNotes();
+      });
+
+      expect(result.current.friendNotes).toEqual(mockFriendNotes);
+      expect(result.current.friendList).toEqual(mockFriends);
+      expect(result.current.isFriendNotesLoading).toBe(false);
+    });
+
+    it("로드 실패 시 빈 배열을 유지해야 한다", async () => {
+      mockGetFriendsSharedWrongNotes.mockRejectedValue(new Error("실패"));
+
+      const { result } = renderHook(() => useFriendWrongNotes());
+
+      await act(async () => {
+        await result.current.loadFriendNotes();
+      });
+
+      expect(result.current.friendNotes).toEqual([]);
+      expect(result.current.isFriendNotesLoading).toBe(false);
+    });
+  });
+
+  describe("getFriendDisplayName", () => {
+    it("displayName이 있으면 반환해야 한다", async () => {
+      mockGetFriendsSharedWrongNotes.mockResolvedValue(mockFriendNotes);
+      mockGetFriendList.mockResolvedValue(mockFriends);
+
+      const { result } = renderHook(() => useFriendWrongNotes());
+
+      await act(async () => {
+        await result.current.loadFriendNotes();
+      });
+
+      expect(result.current.getFriendDisplayName("friend-1")).toBe("친구일");
+    });
+
+    it("displayName이 없으면 email을 반환해야 한다", async () => {
+      mockGetFriendsSharedWrongNotes.mockResolvedValue(mockFriendNotes);
+      mockGetFriendList.mockResolvedValue(mockFriends);
+
+      const { result } = renderHook(() => useFriendWrongNotes());
+
+      await act(async () => {
+        await result.current.loadFriendNotes();
+      });
+
+      expect(result.current.getFriendDisplayName("friend-2")).toBe(
+        "f2@test.com",
+      );
+    });
+
+    it("친구 목록에 없으면 '알 수 없음'을 반환해야 한다", async () => {
+      mockGetFriendsSharedWrongNotes.mockResolvedValue([]);
+      mockGetFriendList.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useFriendWrongNotes());
+
+      await act(async () => {
+        await result.current.loadFriendNotes();
+      });
+
+      expect(result.current.getFriendDisplayName("unknown")).toBe("알 수 없음");
+    });
+  });
+
+  describe("getFilteredFriendNotes", () => {
+    const emptyFilters: Filters = {
+      platform: "",
+      category: "",
+      result: "",
+      language: "",
+      tag: "",
+    };
+
+    it("필터 없으면 전체를 반환해야 한다", async () => {
+      mockGetFriendsSharedWrongNotes.mockResolvedValue(mockFriendNotes);
+      mockGetFriendList.mockResolvedValue(mockFriends);
+
+      const { result } = renderHook(() => useFriendWrongNotes());
+
+      await act(async () => {
+        await result.current.loadFriendNotes();
+      });
+
+      const filtered = result.current.getFilteredFriendNotes(emptyFilters, "");
+      expect(filtered).toHaveLength(2);
+    });
+
+    it("friendFilter로 특정 친구의 노트만 필터링해야 한다", async () => {
+      mockGetFriendsSharedWrongNotes.mockResolvedValue(mockFriendNotes);
+      mockGetFriendList.mockResolvedValue(mockFriends);
+
+      const { result } = renderHook(() => useFriendWrongNotes());
+
+      await act(async () => {
+        await result.current.loadFriendNotes();
+      });
+
+      act(() => {
+        result.current.setFriendFilter("friend-1");
+      });
+
+      const filtered = result.current.getFilteredFriendNotes(emptyFilters, "");
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].userId).toBe("friend-1");
+    });
+
+    it("platform 필터를 적용해야 한다", async () => {
+      mockGetFriendsSharedWrongNotes.mockResolvedValue(mockFriendNotes);
+      mockGetFriendList.mockResolvedValue(mockFriends);
+
+      const { result } = renderHook(() => useFriendWrongNotes());
+
+      await act(async () => {
+        await result.current.loadFriendNotes();
+      });
+
+      const filtered = result.current.getFilteredFriendNotes(
+        { ...emptyFilters, platform: "baekjoon" },
+        "",
+      );
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].platform).toBe("baekjoon");
+    });
+
+    it("검색어로 title을 필터링해야 한다", async () => {
+      mockGetFriendsSharedWrongNotes.mockResolvedValue(mockFriendNotes);
+      mockGetFriendList.mockResolvedValue(mockFriends);
+
+      const { result } = renderHook(() => useFriendWrongNotes());
+
+      await act(async () => {
+        await result.current.loadFriendNotes();
+      });
+
+      const filtered = result.current.getFilteredFriendNotes(
+        emptyFilters,
+        "DP",
+      );
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].title).toBe("친구의 DP 문제");
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/wrong-note/model/useFriendWrongNotes.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useFriendWrongNotes.ts
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { getFriendsSharedWrongNotes } from "../api/wrong-note.api";
+import { getFriendList } from "@/entities/friend/api/friend.api";
+import type { WrongNote, Filters } from "./wrong-note.type";
+import type { FriendInfo } from "@/entities/friend/model/friend.type";
+
+export function useFriendWrongNotes() {
+  const [friendNotes, setFriendNotes] = useState<WrongNote[]>([]);
+  const [friendList, setFriendList] = useState<FriendInfo[]>([]);
+  const [isFriendNotesLoading, setIsFriendNotesLoading] = useState(false);
+  const [friendFilter, setFriendFilter] = useState("");
+
+  const loadFriendNotes = async () => {
+    try {
+      setIsFriendNotesLoading(true);
+      const [notes, friends] = await Promise.all([
+        getFriendsSharedWrongNotes(),
+        getFriendList(),
+      ]);
+      setFriendNotes(notes);
+      setFriendList(friends);
+    } catch (error) {
+      console.error("친구 오답노트 조회 실패:", error);
+    } finally {
+      setIsFriendNotesLoading(false);
+    }
+  };
+
+  const getFriendDisplayName = (userId: string): string => {
+    const friend = friendList.find((f) => f.odUserId === userId);
+    return friend?.displayName || friend?.email || "알 수 없음";
+  };
+
+  const getFilteredFriendNotes = (filters: Filters, searchQuery: string) => {
+    return friendNotes.filter((note) => {
+      if (friendFilter && note.userId !== friendFilter) return false;
+      if (filters.platform && note.platform !== filters.platform) return false;
+      if (filters.category && note.category !== filters.category) return false;
+      if (filters.result && note.result !== filters.result) return false;
+      if (filters.language && note.language !== filters.language) return false;
+      if (searchQuery) {
+        const query = searchQuery.toLowerCase();
+        const matchesTitle = note.title?.toLowerCase().includes(query);
+        const matchesLink = note.link?.toLowerCase().includes(query);
+        if (!matchesTitle && !matchesLink) return false;
+      }
+      return true;
+    });
+  };
+
+  return {
+    friendNotes,
+    friendList,
+    friendFilter,
+    setFriendFilter,
+    isFriendNotesLoading,
+    loadFriendNotes,
+    getFriendDisplayName,
+    getFilteredFriendNotes,
+  };
+}

--- a/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteDetail.spec.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteDetail.spec.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useWrongNoteDetail } from "./useWrongNoteDetail";
+import type { WrongNote } from "./wrong-note.type";
+
+// --- Mocks ---
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockGetWrongNoteById = vi.fn();
+const mockDeleteWrongNote = vi.fn();
+
+vi.mock("../api/wrong-note.api", () => ({
+  getWrongNoteById: (...args: unknown[]) => mockGetWrongNoteById(...args),
+  deleteWrongNote: (...args: unknown[]) => mockDeleteWrongNote(...args),
+}));
+
+const mockAlert = vi.fn();
+const mockConfirm = vi.fn();
+vi.stubGlobal("alert", mockAlert);
+vi.stubGlobal("confirm", mockConfirm);
+
+// --- Test Data ---
+
+const mockNote: WrongNote = {
+  id: "note-1",
+  userId: "user1",
+  userEmail: "test@test.com",
+  title: "테스트 오답노트",
+  link: "https://programmers.co.kr/1",
+  language: "python",
+  category: "dp",
+  date: "2026-01-01",
+  platform: "programmers",
+  grade: "lv2",
+  myCode: "print('hello')",
+  solution: "print('world')",
+  comment: "메모",
+  share: false,
+  tags: ["algorithm_fail"],
+  result: "wrong",
+  createdAt: new Date("2026-01-01"),
+};
+
+// --- Tests ---
+
+describe("useWrongNoteDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("초기 상태", () => {
+    it("note가 null이어야 한다", () => {
+      mockGetWrongNoteById.mockResolvedValue({ note: null, isOwner: false });
+
+      const { result } = renderHook(() => useWrongNoteDetail(undefined));
+      expect(result.current.note).toBeNull();
+    });
+
+    it("isEditMode가 false여야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteDetail(undefined));
+      expect(result.current.isEditMode).toBe(false);
+    });
+  });
+
+  describe("데이터 로드", () => {
+    it("id가 있으면 오답노트를 로드해야 한다", async () => {
+      mockGetWrongNoteById.mockResolvedValue({
+        note: mockNote,
+        isOwner: true,
+      });
+
+      const { result } = renderHook(() => useWrongNoteDetail("note-1"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.note).toEqual(mockNote);
+      expect(result.current.isOwner).toBe(true);
+    });
+
+    it("id가 없으면 API를 호출하지 않아야 한다", async () => {
+      const { result } = renderHook(() => useWrongNoteDetail(undefined));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetWrongNoteById).not.toHaveBeenCalled();
+    });
+
+    it("로드 실패 시 note가 null로 유지되어야 한다", async () => {
+      mockGetWrongNoteById.mockRejectedValue(new Error("조회 실패"));
+
+      const { result } = renderHook(() => useWrongNoteDetail("note-1"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.note).toBeNull();
+    });
+  });
+
+  describe("handleDelete", () => {
+    it("note가 없으면 삭제하지 않아야 한다", async () => {
+      const { result } = renderHook(() => useWrongNoteDetail(undefined));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.handleDelete();
+      });
+
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockDeleteWrongNote).not.toHaveBeenCalled();
+    });
+
+    it("confirm 취소 시 삭제하지 않아야 한다", async () => {
+      mockGetWrongNoteById.mockResolvedValue({
+        note: mockNote,
+        isOwner: true,
+      });
+      mockConfirm.mockReturnValue(false);
+
+      const { result } = renderHook(() => useWrongNoteDetail("note-1"));
+
+      await waitFor(() => {
+        expect(result.current.note).not.toBeNull();
+      });
+
+      await act(async () => {
+        await result.current.handleDelete();
+      });
+
+      expect(mockDeleteWrongNote).not.toHaveBeenCalled();
+    });
+
+    it("삭제 성공 시 오답노트 목록으로 이동해야 한다", async () => {
+      mockGetWrongNoteById.mockResolvedValue({
+        note: mockNote,
+        isOwner: true,
+      });
+      mockConfirm.mockReturnValue(true);
+      mockDeleteWrongNote.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useWrongNoteDetail("note-1"));
+
+      await waitFor(() => {
+        expect(result.current.note).not.toBeNull();
+      });
+
+      await act(async () => {
+        await result.current.handleDelete();
+      });
+
+      expect(mockDeleteWrongNote).toHaveBeenCalledWith("note-1");
+      expect(mockNavigate).toHaveBeenCalledWith("/wrong-notes");
+    });
+
+    it("삭제 실패 시 alert을 표시해야 한다", async () => {
+      mockGetWrongNoteById.mockResolvedValue({
+        note: mockNote,
+        isOwner: true,
+      });
+      mockConfirm.mockReturnValue(true);
+      mockDeleteWrongNote.mockRejectedValue(new Error("삭제 실패"));
+
+      const { result } = renderHook(() => useWrongNoteDetail("note-1"));
+
+      await waitFor(() => {
+        expect(result.current.note).not.toBeNull();
+      });
+
+      await act(async () => {
+        await result.current.handleDelete();
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("삭제에 실패했습니다.");
+    });
+  });
+
+  describe("noteToFormData", () => {
+    it("WrongNote를 FormData로 변환해야 한다", async () => {
+      mockGetWrongNoteById.mockResolvedValue({
+        note: mockNote,
+        isOwner: true,
+      });
+
+      const { result } = renderHook(() => useWrongNoteDetail("note-1"));
+
+      await waitFor(() => {
+        expect(result.current.note).not.toBeNull();
+      });
+
+      const formData = result.current.noteToFormData(mockNote);
+
+      expect(formData).toEqual({
+        title: "테스트 오답노트",
+        link: "https://programmers.co.kr/1",
+        language: "python",
+        date: "2026-01-01",
+        platform: "programmers",
+        grade: "lv2",
+        category: "dp",
+        myCode: "print('hello')",
+        solution: "print('world')",
+        comment: "메모",
+        share: false,
+        tags: ["algorithm_fail"],
+        result: "wrong",
+      });
+    });
+  });
+
+  describe("편집 모드", () => {
+    it("setIsEditMode로 편집 모드를 활성화할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteDetail(undefined));
+
+      act(() => {
+        result.current.setIsEditMode(true);
+      });
+
+      expect(result.current.isEditMode).toBe(true);
+    });
+
+    it("handleCancel로 편집 모드를 종료할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteDetail(undefined));
+
+      act(() => {
+        result.current.setIsEditMode(true);
+      });
+
+      act(() => {
+        result.current.handleCancel();
+      });
+
+      expect(result.current.isEditMode).toBe(false);
+    });
+
+    it("handleSaveSuccess로 편집 모드를 종료하고 alert을 표시해야 한다", async () => {
+      mockGetWrongNoteById.mockResolvedValue({
+        note: mockNote,
+        isOwner: true,
+      });
+
+      const { result } = renderHook(() => useWrongNoteDetail("note-1"));
+
+      await waitFor(() => {
+        expect(result.current.note).not.toBeNull();
+      });
+
+      act(() => {
+        result.current.setIsEditMode(true);
+      });
+
+      act(() => {
+        result.current.handleSaveSuccess();
+      });
+
+      expect(result.current.isEditMode).toBe(false);
+      expect(mockAlert).toHaveBeenCalledWith("수정되었습니다.");
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteDetail.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteDetail.ts
@@ -1,0 +1,86 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { getWrongNoteById, deleteWrongNote } from "../api/wrong-note.api";
+import type { WrongNote, FormData } from "./wrong-note.type";
+
+export function useWrongNoteDetail(id: string | undefined) {
+  const navigate = useNavigate();
+  const [note, setNote] = useState<WrongNote | null>(null);
+  const [isOwner, setIsOwner] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEditMode, setIsEditMode] = useState(false);
+
+  useEffect(() => {
+    const loadNote = async () => {
+      if (!id) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const { note: found, isOwner: owner } = await getWrongNoteById(id);
+        setNote(found);
+        setIsOwner(owner);
+      } catch (error) {
+        console.error("조회 실패:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadNote();
+  }, [id]);
+
+  const handleDelete = async () => {
+    if (!note?.id || !confirm("정말 삭제하시겠습니까?")) return;
+
+    try {
+      await deleteWrongNote(note.id);
+      navigate("/wrong-notes");
+    } catch (error) {
+      console.error("삭제 실패:", error);
+      alert("삭제에 실패했습니다.");
+    }
+  };
+
+  const noteToFormData = (n: WrongNote): FormData => ({
+    title: n.title || "",
+    link: n.link,
+    language: n.language || "",
+    date: n.date,
+    platform: n.platform,
+    grade: n.grade,
+    category: n.category,
+    myCode: n.myCode,
+    solution: n.solution,
+    comment: n.comment,
+    share: n.share,
+    tags: n.tags,
+    result: n.result,
+  });
+
+  const handleSaveSuccess = () => {
+    if (note) {
+      const updatedNote = { ...note };
+      setNote(updatedNote);
+    }
+    setIsEditMode(false);
+    alert("수정되었습니다.");
+  };
+
+  const handleCancel = () => {
+    setIsEditMode(false);
+  };
+
+  return {
+    note,
+    isOwner,
+    isLoading,
+    isEditMode,
+    setIsEditMode,
+    handleDelete,
+    handleCancel,
+    handleSaveSuccess,
+    noteToFormData,
+  };
+}

--- a/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteFilter.spec.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteFilter.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWrongNoteFilter } from "./useWrongNoteFilter";
+
+describe("useWrongNoteFilter", () => {
+  describe("초기 상태", () => {
+    it("모든 필터가 빈 문자열이어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      expect(result.current.filters).toEqual({
+        platform: "",
+        category: "",
+        language: "",
+        result: "",
+        tag: "",
+      });
+    });
+
+    it("sortBy 기본값은 latest여야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+      expect(result.current.sortBy).toBe("latest");
+    });
+
+    it("searchQuery 기본값은 빈 문자열이어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+      expect(result.current.searchQuery).toBe("");
+    });
+
+    it("활성 필터가 없어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+  });
+
+  describe("handleFilterChange", () => {
+    it("특정 필터 키를 변경할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      act(() => {
+        result.current.handleFilterChange("platform", "programmers");
+      });
+
+      expect(result.current.filters.platform).toBe("programmers");
+      expect(result.current.filters.category).toBe("");
+    });
+
+    it("여러 필터를 동시에 설정할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      act(() => {
+        result.current.handleFilterChange("platform", "baekjoon");
+        result.current.handleFilterChange("result", "correct");
+      });
+
+      expect(result.current.filters.platform).toBe("baekjoon");
+      expect(result.current.filters.result).toBe("correct");
+    });
+  });
+
+  describe("handleSortByChange", () => {
+    it("정렬 기준을 변경할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      act(() => {
+        result.current.handleSortByChange("oldest");
+      });
+
+      expect(result.current.sortBy).toBe("oldest");
+    });
+  });
+
+  describe("hasActiveFilters", () => {
+    it("platform 필터가 설정되면 true여야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      act(() => {
+        result.current.handleFilterChange("platform", "programmers");
+      });
+
+      expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it("result 필터가 설정되면 true여야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      act(() => {
+        result.current.handleFilterChange("result", "wrong");
+      });
+
+      expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it("searchQuery가 설정되면 true여야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      act(() => {
+        result.current.setSearchQuery("검색어");
+      });
+
+      expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it("category, language 필터만 설정되면 false여야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      act(() => {
+        result.current.handleFilterChange("category", "dp");
+        result.current.handleFilterChange("language", "python");
+      });
+
+      // hasActiveFilters는 platform, result, tag, searchQuery만 체크
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+  });
+
+  describe("clearFilters", () => {
+    it("모든 필터와 검색어를 초기화해야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      act(() => {
+        result.current.handleFilterChange("platform", "programmers");
+        result.current.handleFilterChange("result", "correct");
+        result.current.handleFilterChange("tag", "algorithm_fail");
+        result.current.setSearchQuery("검색어");
+      });
+
+      expect(result.current.hasActiveFilters).toBe(true);
+
+      act(() => {
+        result.current.clearFilters();
+      });
+
+      expect(result.current.filters).toEqual({
+        platform: "",
+        category: "",
+        language: "",
+        result: "",
+        tag: "",
+      });
+      expect(result.current.searchQuery).toBe("");
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+
+    it("sortBy는 초기화하지 않아야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteFilter());
+
+      act(() => {
+        result.current.handleSortByChange("oldest");
+        result.current.handleFilterChange("platform", "baekjoon");
+      });
+
+      act(() => {
+        result.current.clearFilters();
+      });
+
+      expect(result.current.sortBy).toBe("oldest");
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteForm.spec.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteForm.spec.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWrongNoteForm } from "./useWrongNoteForm";
+
+// --- Mocks ---
+
+const mockSaveWrongNote = vi.fn();
+const mockUpdateWrongNote = vi.fn();
+
+vi.mock("../api/wrong-note.api", () => ({
+  saveWrongNote: (...args: unknown[]) => mockSaveWrongNote(...args),
+  updateWrongNote: (...args: unknown[]) => mockUpdateWrongNote(...args),
+}));
+
+vi.mock("@/shared/lib/options", () => ({
+  programmersGrades: [
+    { value: "lv1", label: "Lv.1" },
+    { value: "lv2", label: "Lv.2" },
+  ],
+  baekjoonGrades: [
+    { value: "골드1", label: "골드 1" },
+    { value: "실버1", label: "실버 1" },
+  ],
+}));
+
+const mockAlert = vi.fn();
+vi.stubGlobal("alert", mockAlert);
+
+// --- Tests ---
+
+describe("useWrongNoteForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("초기 상태", () => {
+    it("기본 초기값으로 폼이 생성되어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      expect(result.current.formData).toEqual({
+        title: "",
+        link: "",
+        language: "",
+        date: "",
+        platform: "",
+        category: "",
+        grade: "",
+        myCode: "",
+        solution: "",
+        comment: "",
+        share: false,
+        tags: [],
+        result: "",
+      });
+      expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it("initialData가 있으면 해당 값으로 초기화되어야 한다", () => {
+      const initialData = {
+        title: "기존 제목",
+        link: "https://example.com",
+        language: "python",
+        date: "2026-01-01",
+        platform: "programmers",
+        category: "dp",
+        grade: "lv2",
+        myCode: "print('hello')",
+        solution: "print('world')",
+        comment: "풀이 메모",
+        share: true,
+        tags: ["algorithm_fail"],
+        result: "wrong",
+      };
+
+      const { result } = renderHook(() =>
+        useWrongNoteForm({ initialData }),
+      );
+
+      expect(result.current.formData).toEqual(initialData);
+    });
+  });
+
+  describe("handleInputChange", () => {
+    it("문자열 필드를 변경할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      act(() => {
+        result.current.handleInputChange("title", "새 제목");
+      });
+
+      expect(result.current.formData.title).toBe("새 제목");
+    });
+
+    it("boolean 필드를 변경할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      act(() => {
+        result.current.handleInputChange("share", true);
+      });
+
+      expect(result.current.formData.share).toBe(true);
+    });
+
+    it("배열 필드를 변경할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      act(() => {
+        result.current.handleInputChange("tags", ["algorithm_fail", "misunderstand"]);
+      });
+
+      expect(result.current.formData.tags).toEqual(["algorithm_fail", "misunderstand"]);
+    });
+  });
+
+  describe("handlePlatformChange", () => {
+    it("플랫폼 변경 시 grade를 초기화해야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      act(() => {
+        result.current.handleInputChange("grade", "lv2");
+        result.current.handlePlatformChange("baekjoon");
+      });
+
+      expect(result.current.formData.platform).toBe("baekjoon");
+      expect(result.current.formData.grade).toBe("");
+    });
+  });
+
+  describe("getGradeOptions", () => {
+    it("programmers 플랫폼이면 프로그래머스 등급을 반환해야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      act(() => {
+        result.current.handlePlatformChange("programmers");
+      });
+
+      const options = result.current.getGradeOptions();
+      expect(options).toEqual([
+        { value: "lv1", label: "Lv.1" },
+        { value: "lv2", label: "Lv.2" },
+      ]);
+    });
+
+    it("baekjoon 플랫폼이면 백준 등급을 반환해야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      act(() => {
+        result.current.handlePlatformChange("baekjoon");
+      });
+
+      const options = result.current.getGradeOptions();
+      expect(options).toEqual([
+        { value: "골드1", label: "골드 1" },
+        { value: "실버1", label: "실버 1" },
+      ]);
+    });
+
+    it("플랫폼이 없으면 빈 배열을 반환해야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      const options = result.current.getGradeOptions();
+      expect(options).toEqual([]);
+    });
+  });
+
+  describe("resetForm", () => {
+    it("폼을 기본 초기값으로 리셋해야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      act(() => {
+        result.current.handleInputChange("title", "입력된 제목");
+        result.current.handleInputChange("share", true);
+      });
+
+      act(() => {
+        result.current.resetForm();
+      });
+
+      expect(result.current.formData.title).toBe("");
+      expect(result.current.formData.share).toBe(false);
+    });
+
+    it("initialData가 있으면 해당 값으로 리셋해야 한다", () => {
+      const initialData = {
+        title: "초기 제목",
+        link: "",
+        language: "python",
+        date: "",
+        platform: "",
+        category: "",
+        grade: "",
+        myCode: "",
+        solution: "",
+        comment: "",
+        share: false,
+        tags: [],
+        result: "",
+      };
+
+      const { result } = renderHook(() =>
+        useWrongNoteForm({ initialData }),
+      );
+
+      act(() => {
+        result.current.handleInputChange("title", "변경된 제목");
+      });
+
+      act(() => {
+        result.current.resetForm();
+      });
+
+      expect(result.current.formData.title).toBe("초기 제목");
+    });
+  });
+
+  describe("setInitialData", () => {
+    it("외부에서 폼 데이터를 직접 설정할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      const newData = {
+        title: "외부 데이터",
+        link: "https://test.com",
+        language: "java",
+        date: "2026-02-01",
+        platform: "baekjoon",
+        category: "graph",
+        grade: "골드1",
+        myCode: "code",
+        solution: "sol",
+        comment: "memo",
+        share: true,
+        tags: ["implementation_fail"],
+        result: "timeout",
+      };
+
+      act(() => {
+        result.current.setInitialData(newData);
+      });
+
+      expect(result.current.formData).toEqual(newData);
+    });
+  });
+
+  describe("handleSubmit", () => {
+    it("생성 모드에서 saveWrongNote를 호출해야 한다", async () => {
+      mockSaveWrongNote.mockResolvedValue(undefined);
+      const onSuccess = vi.fn();
+
+      const { result } = renderHook(() =>
+        useWrongNoteForm({ onSuccess }),
+      );
+
+      act(() => {
+        result.current.handleInputChange("title", "제목");
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockSaveWrongNote).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "제목" }),
+      );
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it("편집 모드에서 updateWrongNote를 호출해야 한다", async () => {
+      mockUpdateWrongNote.mockResolvedValue(undefined);
+      const onSuccess = vi.fn();
+
+      const { result } = renderHook(() =>
+        useWrongNoteForm({ noteId: "note-123", onSuccess }),
+      );
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockUpdateWrongNote).toHaveBeenCalledWith(
+        "note-123",
+        expect.any(Object),
+      );
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it("저장 실패 시 alert을 표시해야 한다", async () => {
+      mockSaveWrongNote.mockRejectedValue(new Error("저장 실패"));
+
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("저장에 실패했습니다.");
+    });
+
+    it("제출 중 중복 호출을 방지해야 한다", async () => {
+      let resolvePromise: () => void;
+      mockSaveWrongNote.mockImplementation(
+        () => new Promise<void>((resolve) => { resolvePromise = resolve; }),
+      );
+
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      let firstSubmit: Promise<void>;
+      act(() => {
+        firstSubmit = result.current.handleSubmit();
+      });
+
+      // isSubmitting이 true인 상태에서 재호출
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      // saveWrongNote는 1번만 호출되어야 함
+      expect(mockSaveWrongNote).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolvePromise!();
+        await firstSubmit!;
+      });
+    });
+
+    it("제출 완료 후 isSubmitting이 false가 되어야 한다", async () => {
+      mockSaveWrongNote.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useWrongNoteForm());
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(result.current.isSubmitting).toBe(false);
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteForm.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteForm.ts
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import {
+  saveWrongNote,
+  updateWrongNote,
+} from "../api/wrong-note.api";
+import type { FormData } from "./wrong-note.type";
+import { programmersGrades, baekjoonGrades } from "@/shared/lib/options";
+
+const INITIAL_FORM_DATA: FormData = {
+  title: "",
+  link: "",
+  language: "",
+  date: "",
+  platform: "",
+  category: "",
+  grade: "",
+  myCode: "",
+  solution: "",
+  comment: "",
+  share: false,
+  tags: [],
+  result: "",
+};
+
+interface UseWrongNoteFormOptions {
+  initialData?: FormData;
+  noteId?: string;
+  onSuccess?: () => void;
+}
+
+export function useWrongNoteForm(options?: UseWrongNoteFormOptions) {
+  const [formData, setFormData] = useState<FormData>(
+    options?.initialData ?? { ...INITIAL_FORM_DATA },
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleInputChange = (field: keyof FormData, value: string | boolean | string[]) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handlePlatformChange = (value: string) => {
+    setFormData((prev) => ({ ...prev, platform: value, grade: "" }));
+  };
+
+  const getGradeOptions = () => {
+    if (formData.platform === "programmers") return programmersGrades;
+    if (formData.platform === "baekjoon") return baekjoonGrades;
+    return [];
+  };
+
+  const resetForm = () => {
+    setFormData(options?.initialData ?? { ...INITIAL_FORM_DATA });
+  };
+
+  const setInitialData = (data: FormData) => {
+    setFormData(data);
+  };
+
+  const handleSubmit = async () => {
+    if (isSubmitting) return;
+
+    try {
+      setIsSubmitting(true);
+
+      if (options?.noteId) {
+        await updateWrongNote(options.noteId, formData);
+      } else {
+        await saveWrongNote(formData);
+      }
+
+      options?.onSuccess?.();
+    } catch (error) {
+      console.error("저장 실패:", error);
+      alert("저장에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    formData,
+    isSubmitting,
+    handleInputChange,
+    handlePlatformChange,
+    getGradeOptions,
+    handleSubmit,
+    resetForm,
+    setInitialData,
+  };
+}

--- a/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteList.spec.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteList.spec.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useWrongNoteList } from "./useWrongNoteList";
+import type { WrongNote, Filters } from "./wrong-note.type";
+
+// --- Mocks ---
+
+const mockGetWrongNotes = vi.fn();
+const mockDeleteWrongNote = vi.fn();
+
+vi.mock("../api/wrong-note.api", () => ({
+  getWrongNotes: (...args: unknown[]) => mockGetWrongNotes(...args),
+  deleteWrongNote: (...args: unknown[]) => mockDeleteWrongNote(...args),
+}));
+
+const mockAlert = vi.fn();
+const mockConfirm = vi.fn();
+vi.stubGlobal("alert", mockAlert);
+vi.stubGlobal("confirm", mockConfirm);
+
+// --- Test Data ---
+
+const mockNotes: WrongNote[] = [
+  {
+    id: "1",
+    userId: "user1",
+    userEmail: "test@test.com",
+    title: "두 수의 합",
+    link: "https://programmers.co.kr/1",
+    language: "python",
+    category: "dp",
+    date: "2026-01-01",
+    platform: "programmers",
+    grade: "lv2",
+    myCode: "code1",
+    solution: "sol1",
+    comment: "메모1",
+    share: false,
+    tags: ["algorithm_fail"],
+    result: "wrong",
+    createdAt: new Date("2026-01-01"),
+  },
+  {
+    id: "2",
+    userId: "user1",
+    userEmail: "test@test.com",
+    title: "BFS 탐색",
+    link: "https://baekjoon.com/2",
+    language: "java",
+    category: "bfs",
+    date: "2026-01-02",
+    platform: "baekjoon",
+    grade: "골드3",
+    myCode: "code2",
+    solution: "sol2",
+    comment: "메모2",
+    share: true,
+    tags: ["implementation_fail"],
+    result: "timeout",
+    createdAt: new Date("2026-01-02"),
+  },
+  {
+    id: "3",
+    userId: "user1",
+    userEmail: "test@test.com",
+    title: "그리디 문제",
+    link: "https://programmers.co.kr/3",
+    language: "python",
+    category: "greedy",
+    date: "2026-01-03",
+    platform: "programmers",
+    grade: "lv3",
+    myCode: "code3",
+    solution: "sol3",
+    comment: "",
+    share: false,
+    tags: ["better_solution"],
+    result: "correct",
+    createdAt: new Date("2026-01-03"),
+  },
+];
+
+// --- Tests ---
+
+describe("useWrongNoteList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("초기 상태", () => {
+    it("notes가 빈 배열이어야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteList());
+      expect(result.current.notes).toEqual([]);
+    });
+
+    it("isLoading이 false여야 한다", () => {
+      const { result } = renderHook(() => useWrongNoteList());
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("loadNotes", () => {
+    it("오답노트 목록을 로드해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      expect(result.current.notes).toEqual(mockNotes);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("로드 실패 시 notes를 변경하지 않아야 한다", async () => {
+      mockGetWrongNotes.mockRejectedValue(new Error("조회 실패"));
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      expect(result.current.notes).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("handleDelete", () => {
+    it("confirm 취소 시 삭제하지 않아야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+      mockConfirm.mockReturnValue(false);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      await act(async () => {
+        await result.current.handleDelete("1");
+      });
+
+      expect(mockDeleteWrongNote).not.toHaveBeenCalled();
+      expect(result.current.notes).toHaveLength(3);
+    });
+
+    it("confirm 확인 시 삭제하고 목록에서 제거해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+      mockConfirm.mockReturnValue(true);
+      mockDeleteWrongNote.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      await act(async () => {
+        await result.current.handleDelete("1");
+      });
+
+      expect(mockDeleteWrongNote).toHaveBeenCalledWith("1");
+      expect(result.current.notes).toHaveLength(2);
+      expect(result.current.notes.find((n) => n.id === "1")).toBeUndefined();
+    });
+
+    it("삭제 실패 시 alert을 표시해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+      mockConfirm.mockReturnValue(true);
+      mockDeleteWrongNote.mockRejectedValue(new Error("삭제 실패"));
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      await act(async () => {
+        await result.current.handleDelete("1");
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("삭제에 실패했습니다.");
+      // 삭제 실패 시 목록은 유지
+      expect(result.current.notes).toHaveLength(3);
+    });
+  });
+
+  describe("getFilteredNotes", () => {
+    const emptyFilters: Filters = {
+      platform: "",
+      category: "",
+      result: "",
+      language: "",
+      tag: "",
+    };
+
+    it("필터 없으면 전체 노트를 반환해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      const filtered = result.current.getFilteredNotes(emptyFilters, "");
+      expect(filtered).toHaveLength(3);
+    });
+
+    it("platform 필터를 적용해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      const filtered = result.current.getFilteredNotes(
+        { ...emptyFilters, platform: "programmers" },
+        "",
+      );
+      expect(filtered).toHaveLength(2);
+      expect(filtered.every((n) => n.platform === "programmers")).toBe(true);
+    });
+
+    it("category 필터를 적용해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      const filtered = result.current.getFilteredNotes(
+        { ...emptyFilters, category: "dp" },
+        "",
+      );
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].title).toBe("두 수의 합");
+    });
+
+    it("result 필터를 적용해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      const filtered = result.current.getFilteredNotes(
+        { ...emptyFilters, result: "timeout" },
+        "",
+      );
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].title).toBe("BFS 탐색");
+    });
+
+    it("language 필터를 적용해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      const filtered = result.current.getFilteredNotes(
+        { ...emptyFilters, language: "python" },
+        "",
+      );
+      expect(filtered).toHaveLength(2);
+    });
+
+    it("tag 필터를 적용해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      const filtered = result.current.getFilteredNotes(
+        { ...emptyFilters, tag: "algorithm_fail" },
+        "",
+      );
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].id).toBe("1");
+    });
+
+    it("검색어로 title을 필터링해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      const filtered = result.current.getFilteredNotes(emptyFilters, "BFS");
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].title).toBe("BFS 탐색");
+    });
+
+    it("검색어로 link를 필터링해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      const filtered = result.current.getFilteredNotes(
+        emptyFilters,
+        "baekjoon",
+      );
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].id).toBe("2");
+    });
+
+    it("여러 필터를 복합 적용해야 한다", async () => {
+      mockGetWrongNotes.mockResolvedValue(mockNotes);
+
+      const { result } = renderHook(() => useWrongNoteList());
+
+      await act(async () => {
+        await result.current.loadNotes();
+      });
+
+      const filtered = result.current.getFilteredNotes(
+        { ...emptyFilters, platform: "programmers", language: "python" },
+        "",
+      );
+      expect(filtered).toHaveLength(2);
+    });
+  });
+});

--- a/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteList.spec.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteList.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { useWrongNoteList } from "./useWrongNoteList";
 import type { WrongNote, Filters } from "./wrong-note.type";
 

--- a/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteList.ts
+++ b/Template-Tester_FE/src/entities/wrong-note/model/useWrongNoteList.ts
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { getWrongNotes, deleteWrongNote } from "../api/wrong-note.api";
+import type { WrongNote, Filters } from "./wrong-note.type";
+
+export function useWrongNoteList() {
+  const [notes, setNotes] = useState<WrongNote[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadNotes = async () => {
+    try {
+      setIsLoading(true);
+      const data = await getWrongNotes();
+      setNotes(data);
+    } catch (error) {
+      console.error("조회 실패:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDelete = async (noteId: string) => {
+    if (!confirm("정말 삭제하시겠습니까?")) return;
+
+    try {
+      await deleteWrongNote(noteId);
+      setNotes((prev) => prev.filter((n) => n.id !== noteId));
+    } catch (error) {
+      console.error("삭제 실패:", error);
+      alert("삭제에 실패했습니다.");
+    }
+  };
+
+  const getFilteredNotes = (filters: Filters, searchQuery: string) => {
+    return notes.filter((note) => {
+      if (filters.platform && note.platform !== filters.platform) return false;
+      if (filters.category && note.category !== filters.category) return false;
+      if (filters.result && note.result !== filters.result) return false;
+      if (filters.language && note.language !== filters.language) return false;
+      if (filters.tag && !note.tags.includes(filters.tag)) return false;
+      if (searchQuery) {
+        const query = searchQuery.toLowerCase();
+        const matchesTitle = note.title?.toLowerCase().includes(query);
+        const matchesLink = note.link?.toLowerCase().includes(query);
+        if (!matchesTitle && !matchesLink) return false;
+      }
+      return true;
+    });
+  };
+
+  return {
+    notes,
+    isLoading,
+    loadNotes,
+    handleDelete,
+    getFilteredNotes,
+  };
+}

--- a/Template-Tester_FE/src/features/grading/model/useGrading.spec.ts
+++ b/Template-Tester_FE/src/features/grading/model/useGrading.spec.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useGrading } from "./useGrading";
+
+// --- Mocks ---
+
+const mockGetUserTemplatesByCategory = vi.fn();
+const mockSaveSubmission = vi.fn();
+
+vi.mock("@/entities/template/api/template.api", () => ({
+  getUserTemplatesByCategory: (...args: unknown[]) =>
+    mockGetUserTemplatesByCategory(...args),
+}));
+
+vi.mock("@/entities/submission/api/submission.api", () => ({
+  saveSubmission: (...args: unknown[]) => mockSaveSubmission(...args),
+}));
+
+// gradeAnswer는 실제 로직 사용 (순수 함수이므로 mock 불필요)
+
+const mockAlert = vi.fn();
+vi.stubGlobal("alert", mockAlert);
+
+// scrollIntoView mock
+const mockScrollIntoView = vi.fn();
+
+// --- Test Data ---
+
+const mockTemplates = [
+  {
+    id: "t1",
+    category: "algorithm" as const,
+    title: "정렬 알고리즘",
+    description: "버블 정렬 구현",
+    answer: "function bubbleSort(arr) {\n  return arr.sort();\n}",
+  },
+  {
+    id: "t2",
+    category: "algorithm" as const,
+    title: "이진 탐색",
+    description: "이진 탐색 구현",
+    answer: "function binarySearch(arr, target) {\n  return arr.indexOf(target);\n}",
+  },
+];
+
+// --- Tests ---
+
+describe("useGrading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserTemplatesByCategory.mockResolvedValue(mockTemplates);
+    vi.spyOn(document, "getElementById").mockReturnValue({
+      scrollIntoView: mockScrollIntoView,
+    } as unknown as HTMLElement);
+  });
+
+  describe("초기 상태", () => {
+    it("기본 카테고리는 algorithm이어야 한다", () => {
+      const { result } = renderHook(() => useGrading());
+      expect(result.current.currentCategory).toBe("algorithm");
+    });
+
+    it("selectedTemplateId가 빈 문자열이어야 한다", () => {
+      const { result } = renderHook(() => useGrading());
+      expect(result.current.selectedTemplateId).toBe("");
+    });
+
+    it("userCode가 빈 문자열이어야 한다", () => {
+      const { result } = renderHook(() => useGrading());
+      expect(result.current.userCode).toBe("");
+    });
+
+    it("gradingResult가 null이어야 한다", () => {
+      const { result } = renderHook(() => useGrading());
+      expect(result.current.gradingResult).toBeNull();
+    });
+  });
+
+  describe("템플릿 로드", () => {
+    it("마운트 시 현재 카테고리의 템플릿을 로드해야 한다", async () => {
+      renderHook(() => useGrading());
+
+      await waitFor(() => {
+        expect(mockGetUserTemplatesByCategory).toHaveBeenCalledWith(
+          "algorithm",
+        );
+      });
+    });
+  });
+
+  describe("handleCategoryChange", () => {
+    it("카테고리 변경 시 관련 상태를 초기화해야 한다", async () => {
+      const { result } = renderHook(() => useGrading());
+
+      await waitFor(() => {
+        expect(mockGetUserTemplatesByCategory).toHaveBeenCalled();
+      });
+
+      act(() => {
+        result.current.handleCategoryChange("english");
+      });
+
+      expect(result.current.currentCategory).toBe("english");
+      expect(result.current.selectedTemplateId).toBe("");
+      expect(result.current.userCode).toBe("");
+      expect(result.current.gradingResult).toBeNull();
+    });
+  });
+
+  describe("handleTemplateChange", () => {
+    it("템플릿 변경 시 코드와 결과를 초기화해야 한다", async () => {
+      const { result } = renderHook(() => useGrading());
+
+      await waitFor(() => {
+        expect(mockGetUserTemplatesByCategory).toHaveBeenCalled();
+      });
+
+      act(() => {
+        result.current.setUserCode("some code");
+      });
+
+      act(() => {
+        result.current.handleTemplateChange("t1");
+      });
+
+      expect(result.current.selectedTemplateId).toBe("t1");
+      expect(result.current.userCode).toBe("");
+      expect(result.current.gradingResult).toBeNull();
+    });
+  });
+
+  describe("selectedTemplate", () => {
+    it("selectedTemplateId에 해당하는 템플릿을 반환해야 한다", async () => {
+      const { result } = renderHook(() => useGrading());
+
+      await waitFor(() => {
+        expect(result.current.templates).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.handleTemplateChange("t1");
+      });
+
+      expect(result.current.selectedTemplate?.title).toBe("정렬 알고리즘");
+    });
+
+    it("선택된 템플릿이 없으면 undefined여야 한다", () => {
+      const { result } = renderHook(() => useGrading());
+      expect(result.current.selectedTemplate).toBeUndefined();
+    });
+  });
+
+  describe("handleGrade", () => {
+    it("템플릿 미선택 시 alert을 표시해야 한다", async () => {
+      const { result } = renderHook(() => useGrading());
+
+      await act(async () => {
+        await result.current.handleGrade();
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith("템플릿을 먼저 선택해주세요.");
+    });
+
+    it("채점 후 gradingResult가 설정되어야 한다", async () => {
+      mockSaveSubmission.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useGrading());
+
+      await waitFor(() => {
+        expect(result.current.templates).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.handleTemplateChange("t1");
+      });
+
+      act(() => {
+        result.current.setUserCode(
+          "function bubbleSort(arr) {\n  return arr.sort();\n}",
+        );
+      });
+
+      await act(async () => {
+        await result.current.handleGrade();
+      });
+
+      expect(result.current.gradingResult).not.toBeNull();
+      expect(result.current.gradingResult!.accuracy).toBe(100);
+    });
+
+    it("정답과 다른 코드일 경우 정확도가 100 미만이어야 한다", async () => {
+      mockSaveSubmission.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useGrading());
+
+      await waitFor(() => {
+        expect(result.current.templates).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.handleTemplateChange("t1");
+      });
+
+      act(() => {
+        result.current.setUserCode("function wrongCode() {\n  return null;\n}");
+      });
+
+      await act(async () => {
+        await result.current.handleGrade();
+      });
+
+      expect(result.current.gradingResult).not.toBeNull();
+      expect(result.current.gradingResult!.accuracy).toBeLessThan(100);
+    });
+
+    it("채점 후 saveSubmission을 호출해야 한다", async () => {
+      mockSaveSubmission.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useGrading());
+
+      await waitFor(() => {
+        expect(result.current.templates).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.handleTemplateChange("t1");
+        result.current.setUserCode("test code");
+      });
+
+      await act(async () => {
+        await result.current.handleGrade();
+      });
+
+      expect(mockSaveSubmission).toHaveBeenCalledWith(
+        "t1",
+        "정렬 알고리즘",
+        "algorithm",
+        "test code",
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("handleReset", () => {
+    it("코드와 채점 결과를 초기화해야 한다", async () => {
+      mockSaveSubmission.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useGrading());
+
+      await waitFor(() => {
+        expect(result.current.templates).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.handleTemplateChange("t1");
+        result.current.setUserCode("some code");
+      });
+
+      await act(async () => {
+        await result.current.handleGrade();
+      });
+
+      act(() => {
+        result.current.handleReset();
+      });
+
+      expect(result.current.userCode).toBe("");
+      expect(result.current.gradingResult).toBeNull();
+    });
+
+    it("selectedTemplateId는 유지해야 한다", async () => {
+      const { result } = renderHook(() => useGrading());
+
+      await waitFor(() => {
+        expect(result.current.templates).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.handleTemplateChange("t1");
+      });
+
+      act(() => {
+        result.current.handleReset();
+      });
+
+      expect(result.current.selectedTemplateId).toBe("t1");
+    });
+  });
+});

--- a/Template-Tester_FE/src/features/grading/model/useGrading.ts
+++ b/Template-Tester_FE/src/features/grading/model/useGrading.ts
@@ -1,0 +1,89 @@
+import { useState, useEffect } from "react";
+import type { Category, Template } from "@/entities/template/model/template.type";
+import type { GradingResult } from "@/entities/submission/model/submission.type";
+import { gradeAnswer } from "./grading";
+import { saveSubmission } from "@/entities/submission/api/submission.api";
+import { getUserTemplatesByCategory } from "@/entities/template/api/template.api";
+
+export function useGrading() {
+  const [currentCategory, setCurrentCategory] = useState<Category>("algorithm");
+  const [selectedTemplateId, setSelectedTemplateId] = useState("");
+  const [userCode, setUserCode] = useState("");
+  const [gradingResult, setGradingResult] = useState<GradingResult | null>(null);
+  const [templates, setTemplates] = useState<Template[]>([]);
+
+  const selectedTemplate = templates.find((t) => t.id === selectedTemplateId);
+
+  useEffect(() => {
+    const loadTemplates = async () => {
+      try {
+        const userTemplates = await getUserTemplatesByCategory(currentCategory);
+        setTemplates(userTemplates);
+      } catch (error) {
+        console.error("템플릿 로드 실패:", error);
+      }
+    };
+    loadTemplates();
+  }, [currentCategory]);
+
+  const handleCategoryChange = (category: Category) => {
+    setCurrentCategory(category);
+    setSelectedTemplateId("");
+    setUserCode("");
+    setGradingResult(null);
+  };
+
+  const handleTemplateChange = (templateId: string) => {
+    setSelectedTemplateId(templateId);
+    setUserCode("");
+    setGradingResult(null);
+  };
+
+  const handleGrade = async () => {
+    if (!selectedTemplate) {
+      alert("템플릿을 먼저 선택해주세요.");
+      return;
+    }
+
+    const result = gradeAnswer(selectedTemplate.answer, userCode);
+    setGradingResult(result);
+
+    try {
+      await saveSubmission(
+        selectedTemplate.id,
+        selectedTemplate.title,
+        currentCategory,
+        userCode,
+        result,
+      );
+    } catch (error) {
+      console.error("Firebase 저장 실패:", error);
+    }
+
+    setTimeout(() => {
+      const resultElement = document.getElementById("grading-result");
+      if (resultElement) {
+        resultElement.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    }, 100);
+  };
+
+  const handleReset = () => {
+    setUserCode("");
+    setGradingResult(null);
+  };
+
+  return {
+    currentCategory,
+    templates,
+    selectedTemplateId,
+    selectedTemplate,
+    userCode,
+    setUserCode,
+    gradingResult,
+    handleCategoryChange,
+    handleTemplateChange,
+    handleGrade,
+    handleReset,
+  };
+}

--- a/Template-Tester_FE/src/pages/index.tsx
+++ b/Template-Tester_FE/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Navbar from "@/widgets/Navbar/Navbar";
 import PageHeader from "@/shared/ui/molecules/PageHeader/PageHeader";
@@ -6,12 +5,8 @@ import CodeEditor from "@/shared/ui/molecules/CodeEditor/CodeEditor";
 import GradingResult from "@/features/grading/ui/GradingResult";
 import AppButton from "@/shared/ui/atoms/AppButton/AppButton";
 import AppSelect from "@/shared/ui/atoms/AppSelect/AppSelect";
-
-import type { Category, Template } from "@/entities/template/model/template.type";
-import type { GradingResult as GradingResultType } from "@/entities/submission/model/submission.type";
-import { gradeAnswer } from "@/features/grading/model/grading";
-import { saveSubmission } from "@/entities/submission/api/submission.api";
-import { getUserTemplatesByCategory } from "@/entities/template/api/template.api";
+import { useGrading } from "@/features/grading/model/useGrading";
+import type { Category } from "@/entities/template/model/template.type";
 
 const categories: { value: Category; label: string }[] = [
   { value: "algorithm", label: "알고리즘" },
@@ -22,77 +17,25 @@ const categories: { value: Category; label: string }[] = [
 
 export default function IndexPage() {
   const navigate = useNavigate();
-  const [currentCategory, setCurrentCategory] = useState<Category>("algorithm");
-  const [selectedTemplateId, setSelectedTemplateId] = useState<string>("");
-  const [userCode, setUserCode] = useState<string>("");
-  const [gradingResult, setGradingResult] = useState<GradingResultType | null>(null);
-  const [templates, setTemplates] = useState<Template[]>([]);
-  const selectedTemplate = templates.find((t) => t.id === selectedTemplateId);
-
-  // 사용자 템플릿 불러오기
-  useEffect(() => {
-    const loadTemplates = async () => {
-      try {
-        const userTemplates = await getUserTemplatesByCategory(currentCategory);
-        setTemplates(userTemplates);
-      } catch (error) {
-        console.error("템플릿 로드 실패:", error);
-      }
-    };
-    loadTemplates();
-  }, [currentCategory]);
-
-  const handleCategoryChange = (category: Category) => {
-    setCurrentCategory(category);
-    setSelectedTemplateId("");
-    setUserCode("");
-    setGradingResult(null);
-  };
-
-  const handleTemplateChange = (templateId: string) => {
-    setSelectedTemplateId(templateId);
-    setUserCode("");
-    setGradingResult(null);
-  };
-
-  const handleGrade = async () => {
-    if (!selectedTemplate) {
-      alert("템플릿을 먼저 선택해주세요.");
-      return;
-    }
-
-    const result = gradeAnswer(selectedTemplate.answer, userCode);
-    setGradingResult(result);
-
-    // Firebase에 제출 기록 저장
-    try {
-      await saveSubmission(selectedTemplate.id, selectedTemplate.title, currentCategory, userCode, result);
-      console.log("✅ 제출 기록이 Firebase에 저장되었습니다!");
-    } catch (error) {
-      console.error("❌ Firebase 저장 실패:", error);
-      // 저장 실패해도 채점 결과는 보여줌
-    }
-
-    // 채점 결과 영역으로 스크롤
-    setTimeout(() => {
-      const resultElement = document.getElementById("grading-result");
-      if (resultElement) {
-        resultElement.scrollIntoView({ behavior: "smooth", block: "start" });
-      }
-    }, 100);
-  };
-
-  const handleReset = () => {
-    setUserCode("");
-    setGradingResult(null);
-  };
+  const {
+    currentCategory,
+    templates,
+    selectedTemplateId,
+    selectedTemplate,
+    userCode,
+    setUserCode,
+    gradingResult,
+    handleCategoryChange,
+    handleTemplateChange,
+    handleGrade,
+    handleReset,
+  } = useGrading();
 
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
 
       <div className="max-w-[1400px] mx-auto px-4 py-4 sm:px-6 sm:py-6">
-        {/* 템플릿 선택 영역 */}
         <PageHeader title="템플릿 선택" />
 
         <div className="bg-surface p-3 sm:p-4 rounded-lg border border-border mb-4 sm:mb-6">
@@ -144,7 +87,6 @@ export default function IndexPage() {
           </div>
         )}
 
-        {/* 코드 입력 영역 */}
         {selectedTemplate && (
           <>
             <div className="mb-6">
@@ -162,12 +104,10 @@ export default function IndexPage() {
               <CodeEditor value={userCode} onChange={setUserCode} language="python" />
             </div>
 
-            {/* 채점 결과 영역 */}
             {gradingResult && <GradingResult result={gradingResult} />}
           </>
         )}
 
-        {/* 템플릿 미선택 상태 */}
         {!selectedTemplate && (
           <div className="text-center px-6 py-8 mt-[100px]">
             <div className="text-6xl mb-4">📝</div>

--- a/Template-Tester_FE/src/pages/my-templates.tsx
+++ b/Template-Tester_FE/src/pages/my-templates.tsx
@@ -1,52 +1,21 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Navbar from "@/widgets/Navbar/Navbar";
 import PageHeader from "@/shared/ui/molecules/PageHeader/PageHeader";
 import AppButton from "@/shared/ui/atoms/AppButton/AppButton";
 import AppFallback from "@/shared/ui/molecules/AppFallback/AppFallback";
-import { getUserTemplatesByCategory, deleteUserTemplate } from "@/entities/template/api/template.api";
-import type { Category, Template } from "@/entities/template/model/template.type";
+import { useMyTemplates } from "@/entities/template/model/useMyTemplates";
 
-function MyTemplates() {
+export default function MyTemplates() {
   const navigate = useNavigate();
-  const [currentCategory] = useState<Category>("algorithm");
-  const [templates, setTemplates] = useState<Template[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { templates, isLoading, loadTemplates, handleDelete } = useMyTemplates();
 
   useEffect(() => {
     loadTemplates();
-  }, [currentCategory]);
-
-  const loadTemplates = async () => {
-    try {
-      setIsLoading(true);
-      const data = await getUserTemplatesByCategory(currentCategory);
-      setTemplates(data);
-    } catch (error) {
-      console.error("템플릿 로드 실패:", error);
-      alert("템플릿을 불러오는데 실패했습니다.");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  }, []);
 
   const handleEdit = (templateId: string) => {
     navigate(`/template-registration?id=${templateId}`);
-  };
-
-  const handleDelete = async (templateId: string, title: string) => {
-    if (!confirm(`"${title}" 템플릿을 삭제하시겠습니까?`)) {
-      return;
-    }
-
-    try {
-      await deleteUserTemplate(templateId);
-      alert("템플릿이 삭제되었습니다.");
-      loadTemplates();
-    } catch (error) {
-      console.error("템플릿 삭제 실패:", error);
-      alert("템플릿 삭제에 실패했습니다.");
-    }
   };
 
   const handleCreateNew = () => {
@@ -115,5 +84,3 @@ function MyTemplates() {
     </div>
   );
 }
-
-export default MyTemplates;

--- a/Template-Tester_FE/src/pages/template-registration.tsx
+++ b/Template-Tester_FE/src/pages/template-registration.tsx
@@ -1,108 +1,33 @@
-import { useState, useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import Navbar from "@/widgets/Navbar/Navbar";
 import PageHeader from "@/shared/ui/molecules/PageHeader/PageHeader";
 import AppButton from "@/shared/ui/atoms/AppButton/AppButton";
 import AppSelect from "@/shared/ui/atoms/AppSelect/AppSelect";
 import CodeEditor from "@/shared/ui/molecules/CodeEditor/CodeEditor";
-import { saveUserTemplate, updateUserTemplate, getUserTemplates } from "@/entities/template/api/template.api";
+import { useTemplateForm } from "@/entities/template/model/useTemplateForm";
 import type { Category, TemplateType } from "@/entities/template/model/template.type";
 
-function TemplateRegistration() {
-  const navigate = useNavigate();
+export default function TemplateRegistration() {
   const [searchParams] = useSearchParams();
   const templateId = searchParams.get("id");
-  const isEditMode = !!templateId;
 
-  const [currentCategory, setCurrentCategory] = useState<Category>("algorithm");
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [templateType, setTemplateType] = useState<TemplateType>("paragraph");
-  const [answer, setAnswer] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    if (isEditMode && templateId) {
-      loadTemplateData(templateId);
-    }
-  }, [isEditMode, templateId]);
-
-  const loadTemplateData = async (id: string) => {
-    try {
-      setIsLoading(true);
-      const templates = await getUserTemplates();
-      const template = templates.find((t) => t.id === id);
-
-      if (!template) {
-        alert("템플릿을 찾을 수 없습니다.");
-        navigate("/");
-        return;
-      }
-
-      setCurrentCategory(template.category);
-      setTitle(template.title);
-      setDescription(template.description || "");
-      setAnswer(template.answer);
-      setTemplateType(template.type || "paragraph");
-    } catch (error) {
-      console.error("템플릿 로드 실패:", error);
-      alert("템플릿을 불러오는데 실패했습니다.");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleSubmit = async () => {
-    if (!title.trim()) {
-      alert("템플릿 제목을 입력해주세요.");
-      return;
-    }
-
-    if (!answer.trim()) {
-      alert("정답 내용을 입력해주세요.");
-      return;
-    }
-
-    try {
-      setIsSubmitting(true);
-
-      if (isEditMode && templateId) {
-        await updateUserTemplate(
-          templateId,
-          currentCategory,
-          title,
-          description,
-          answer,
-          templateType
-        );
-        alert("템플릿이 성공적으로 수정되었습니다!");
-      } else {
-        await saveUserTemplate(
-          currentCategory,
-          title,
-          description,
-          answer,
-          templateType
-        );
-        alert("템플릿이 성공적으로 등록되었습니다!");
-      }
-
-      navigate("/my-templates");
-    } catch (error: any) {
-      console.error("템플릿 저장 실패:", error);
-      alert(error.message || "템플릿 저장에 실패했습니다.");
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleReset = () => {
-    setTitle("");
-    setDescription("");
-    setAnswer("");
-    setTemplateType("paragraph");
-  };
+  const {
+    currentCategory,
+    setCurrentCategory,
+    title,
+    setTitle,
+    description,
+    setDescription,
+    templateType,
+    setTemplateType,
+    answer,
+    setAnswer,
+    isSubmitting,
+    isLoading,
+    isEditMode,
+    handleSubmit,
+    handleReset,
+  } = useTemplateForm(templateId);
 
   if (isLoading) {
     return (
@@ -122,13 +47,9 @@ function TemplateRegistration() {
           description={isEditMode ? "등록한 템플릿을 수정합니다." : "나만의 템플릿을 등록하고 연습해보세요."}
         />
 
-        {/* 템플릿 정보 입력 */}
         <div className="bg-surface p-6 rounded-lg border border-border mb-6">
-          {/* 카테고리 선택 */}
           <div className="mb-6">
-            <label className="block text-sm font-semibold text-text mb-2">
-              카테고리
-            </label>
+            <label className="block text-sm font-semibold text-text mb-2">카테고리</label>
             <AppSelect
               value={currentCategory}
               onChange={(value) => setCurrentCategory(value as Category)}
@@ -142,11 +63,8 @@ function TemplateRegistration() {
             />
           </div>
 
-          {/* 템플릿 제목 */}
           <div className="mb-6">
-            <label className="block text-sm font-semibold text-text mb-2">
-              템플릿 제목
-            </label>
+            <label className="block text-sm font-semibold text-text mb-2">템플릿 제목</label>
             <input
               type="text"
               value={title}
@@ -156,11 +74,8 @@ function TemplateRegistration() {
             />
           </div>
 
-          {/* 템플릿 설명 */}
           <div className="mb-6">
-            <label className="block text-sm font-semibold text-text mb-2">
-              템플릿 설명
-            </label>
+            <label className="block text-sm font-semibold text-text mb-2">템플릿 설명</label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -170,11 +85,8 @@ function TemplateRegistration() {
             />
           </div>
 
-          {/* 템플릿 형태 선택 */}
           <div className="mb-6">
-            <label className="block text-sm font-semibold text-text mb-3">
-              템플릿 형태
-            </label>
+            <label className="block text-sm font-semibold text-text mb-3">템플릿 형태</label>
             <div className="flex gap-6">
               <label className="flex items-center cursor-pointer">
                 <input
@@ -207,7 +119,6 @@ function TemplateRegistration() {
           </div>
         </div>
 
-        {/* 정답 입력 영역 */}
         <div className="mb-6">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-semibold text-text m-0">정답 입력</h3>
@@ -225,7 +136,6 @@ function TemplateRegistration() {
           <CodeEditor value={answer} onChange={setAnswer} language="python" />
         </div>
 
-        {/* 안내 메시지 */}
         <div className="bg-surface p-4 rounded-lg border border-border">
           <h4 className="text-sm font-semibold text-text mb-2">입력 가이드</h4>
           <ul className="text-xs text-textSecondary space-y-1 list-disc list-inside">
@@ -239,5 +149,3 @@ function TemplateRegistration() {
     </div>
   );
 }
-
-export default TemplateRegistration;

--- a/Template-Tester_FE/src/shared/lib/useTheme.spec.ts
+++ b/Template-Tester_FE/src/shared/lib/useTheme.spec.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTheme } from "./useTheme";
+
+// --- Mocks ---
+
+const mockMatchMedia = vi.fn();
+const mockAddEventListener = vi.fn();
+const mockRemoveEventListener = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+
+  // matchMedia mock
+  mockMatchMedia.mockReturnValue({
+    matches: false,
+    addEventListener: mockAddEventListener,
+    removeEventListener: mockRemoveEventListener,
+  });
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: mockMatchMedia,
+  });
+
+  // document.documentElement.setAttribute mock
+  vi.spyOn(document.documentElement, "setAttribute");
+});
+
+// --- Tests ---
+
+describe("useTheme", () => {
+  describe("초기 상태", () => {
+    it("localStorage에 값이 없고 시스템이 light이면 light여야 한다", () => {
+      mockMatchMedia.mockReturnValue({
+        matches: false,
+        addEventListener: mockAddEventListener,
+        removeEventListener: mockRemoveEventListener,
+      });
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.theme).toBe("light");
+      expect(result.current.isDark).toBe(false);
+    });
+
+    it("localStorage에 dark가 저장되어 있으면 dark여야 한다", () => {
+      localStorage.setItem("theme", "dark");
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.theme).toBe("dark");
+      expect(result.current.isDark).toBe(true);
+    });
+
+    it("localStorage에 light가 저장되어 있으면 light여야 한다", () => {
+      localStorage.setItem("theme", "light");
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.theme).toBe("light");
+    });
+
+    it("시스템이 다크 모드이고 localStorage가 비어있으면 dark여야 한다", () => {
+      mockMatchMedia.mockReturnValue({
+        matches: true,
+        addEventListener: mockAddEventListener,
+        removeEventListener: mockRemoveEventListener,
+      });
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.theme).toBe("dark");
+    });
+  });
+
+  describe("toggleTheme", () => {
+    it("light에서 dark로 토글해야 한다", () => {
+      localStorage.setItem("theme", "light");
+
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.toggleTheme();
+      });
+
+      expect(result.current.theme).toBe("dark");
+      expect(result.current.isDark).toBe(true);
+    });
+
+    it("dark에서 light로 토글해야 한다", () => {
+      localStorage.setItem("theme", "dark");
+
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.toggleTheme();
+      });
+
+      expect(result.current.theme).toBe("light");
+      expect(result.current.isDark).toBe(false);
+    });
+  });
+
+  describe("setTheme", () => {
+    it("테마를 직접 설정할 수 있어야 한다", () => {
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.setTheme("dark");
+      });
+
+      expect(result.current.theme).toBe("dark");
+    });
+  });
+
+  describe("DOM 업데이트", () => {
+    it("테마 변경 시 data-theme 속성을 업데이트해야 한다", () => {
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.setTheme("dark");
+      });
+
+      expect(document.documentElement.setAttribute).toHaveBeenCalledWith(
+        "data-theme",
+        "dark",
+      );
+    });
+
+    it("테마 변경 시 localStorage에 저장해야 한다", () => {
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.setTheme("dark");
+      });
+
+      expect(localStorage.getItem("theme")).toBe("dark");
+    });
+  });
+
+  describe("시스템 테마 변경 감지", () => {
+    it("matchMedia change 이벤트를 구독해야 한다", () => {
+      renderHook(() => useTheme());
+
+      expect(mockAddEventListener).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function),
+      );
+    });
+
+    it("언마운트 시 이벤트 리스너를 제거해야 한다", () => {
+      const { unmount } = renderHook(() => useTheme());
+
+      unmount();
+
+      expect(mockRemoveEventListener).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/Template-Tester_FE/src/test/setup.ts
+++ b/Template-Tester_FE/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/Template-Tester_FE/src/widgets/Navbar/Navbar.tsx
+++ b/Template-Tester_FE/src/widgets/Navbar/Navbar.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/features/auth/model/useAuth";
 import { logout } from "@/features/auth/api/auth.api";
-import { getReceivedFriendRequests } from "@/entities/friend/api/friend.api";
+import { usePendingRequestCount } from "@/entities/friend/model/usePendingRequestCount";
 import { useTheme } from "@/shared/lib/useTheme";
 
 const menuItems = [
@@ -17,25 +17,8 @@ export default function Navbar() {
   const navigate = useNavigate();
   const location = useLocation();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [pendingRequestCount, setPendingRequestCount] = useState(0);
   const dropdownRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!user) return;
-
-    const loadPendingRequests = async () => {
-      try {
-        const requests = await getReceivedFriendRequests();
-        setPendingRequestCount(requests.length);
-      } catch (error) {
-        console.error("친구 요청 수 로드 실패:", error);
-      }
-    };
-
-    loadPendingRequests();
-    const interval = setInterval(loadPendingRequests, 30000);
-    return () => clearInterval(interval);
-  }, [user]);
+  const { pendingRequestCount } = usePendingRequestCount(!!user);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/Template-Tester_FE/vitest.config.ts
+++ b/Template-Tester_FE/vitest.config.ts
@@ -1,0 +1,25 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.{spec,test}.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/**/*.stories.{ts,tsx}", "src/test/**"],
+    },
+  },
+});


### PR DESCRIPTION
- friend, template, wrong-note, grading, theme 관련 13개 spec 파일 추가
- Vitest, Playwright, React Testing Library 등 테스트 의존성 설치 및 설정 파일 추가

- FSD 컨벤션에 따라 pages에서 entities/features model 레이어로 추출:
  - friend: useFriendList, useFriendRequests, useFriendSearch, usePendingRequestCount
  - template: useMyTemplates, useTemplateForm
  - wrong-note: useWrongNoteList, useWrongNoteDetail, useWrongNoteForm, useFriendWrongNotes
  - grading: useGrading

- Pinia → Zustand, Vue Query → TanStack Query, SCSS → Tailwind CSS,
- Vue SFC → React TSX, auto-import → 명시적 import 등 전체 스택 변경 반영